### PR TITLE
[wip] Update the swisstopo WMTS urls

### DIFF
--- a/base_geoengine/static/src/js/geoengine_view.js
+++ b/base_geoengine/static/src/js/geoengine_view.js
@@ -111,7 +111,7 @@ openerp.base_geoengine = function(openerp) {
                             name: l.name,
                             layer: l.swisstopo_type,
                             formatSuffix: 'jpeg',
-                            url: ['https://wmts0.geo.admin.ch/', 'https://wmts1.geo.admin.ch/', 'https://wmts2.geo.admin.ch/'],
+                            url: ['https://wmts5.geo.admin.ch/', 'https://wmts6.geo.admin.ch/', 'https://wmts7.geo.admin.ch/'],
                             projection: 'EPSG:21781',
                             units: 'm',
                             resolutions: resolutions,


### PR DESCRIPTION
Swisstopo has deprecated the `http://wmts[0-4].geo.admin.ch` range
