### PR TITLE
[9.0] Fix srid value read from column

### DIFF
--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -39,9 +39,12 @@ class GeoField(Field):
     """
 
     geo_type = None
-    dim = 2
-    srid = 900913
-    gist_index = True
+
+    _slots = {
+        'dim': 2,
+        'srid': 900913,
+        'gist_index': True,
+    }
 
     def convert_to_read(self, value, use_name_get=True):
         res = convert.value_to_shape(value)


### PR DESCRIPTION
self._fields.get(column).srid returns always `900913` even when a different srid is set on the field.
