### PR TITLE
Add a button on map widget to clear geometry from the map

### DIFF
--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -110,6 +110,36 @@ div.olControlZoom a:hover {
     background: rgba(0, 60, 136, 0.7);
     filter: alpha(opacity=100);
 }
+div.olControlPanel {
+    margin: 80px 10px;
+}
+
+div.olClearMapItemInactive {
+    border-radius: 4px;
+    float: right;
+    display: block;
+    margin: 1px;
+    padding: 0;
+    color: white;
+    text-align: center;
+    font-size: 18px;
+    font-family: FontAwesome, Verdana;
+    content: "\f1f8";
+    height: 22px;
+    width:22px;
+    background: #130085; /* fallback for IE - IE6 requires background shorthand*/
+    background: rgba(0, 60, 136, 0.5);
+    filter: alpha(opacity=80);
+}
+div.olClearMapItemInactive:before {
+    font-family: FontAwesome, Verdana;
+    content: "\f1f8";
+}
+div.olClearMapItemInactive:hover {
+    background: #130085; /* fallback for IE */
+    background: rgba(0, 60, 136, 0.7);
+    filter: alpha(opacity=100);
+}
 @media only screen and (max-width: 600px) {
     div.olControlZoom a:hover {
         background: rgba(0, 60, 136, 0.5);

--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -162,6 +162,22 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
             this.draw_control = new OpenLayers.Control.DrawFeature(this.layers[1], handler);
             this.map.addControl(this.draw_control);
 
+            function clearMap() {
+                var vl = this.map.getLayersByName(this.widget.name)[0];
+                vl.destroyFeatures();
+                this.widget.set_value(null);
+            }
+            this.modify_panel = new OpenLayers.Control.Panel();
+            clear_button = new OpenLayers.Control.Button({
+                displayClass: 'olClearMap',
+                type: OpenLayers.Control.TYPE_BUTTON,
+                trigger: clearMap,
+                widget: this,
+            })
+            this.modify_panel.addControls([clear_button]);
+
+            this.map.addControl(this.modify_panel);
+
             this.default_extend = OpenLayers.Bounds.fromString(this.default_extent).transform('EPSG:900913', this.map.getProjection());
             this.map.zoomToExtent(this.default_extend);
             this.format = new OpenLayers.Format.GeoJSON({
@@ -174,8 +190,10 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
         }
         if (this.get("effective_readonly") || this.force_readonly) {
             this.modify_control.deactivate();
+            this.modify_panel.deactivate();
         } else {
             this.modify_control.activate();
+            this.modify_panel.activate();
             this.value === false ? this.draw_control.activate() : this.draw_control.deactivate();
         }
     },


### PR DESCRIPTION
Add a trash button below zoom buttons in edit mode to clear geometry.

![2016-02-24-182431_845x526_scrot](https://cloud.githubusercontent.com/assets/4158438/13294365/f0e8ac20-db23-11e5-90cc-b23455bc4c09.png)
