### PR TITLE
[9.0] Fix offset issues on the map by reseting offset when scroll bar is used

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -193,6 +193,10 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
             this.map.render(this.name);
             $(document).trigger('FieldGeoEngineEditMap:ready', [this.map]);
             this.set_value(this.value);
+            view_manager = this.$el.closest(".oe-view-manager")
+            view_manager.on("scroll", {'map': this.map}, function (event) {
+                event.data.map.events.element.offsets = null;
+            });
         }
         if (this.get("effective_readonly") || this.force_readonly) {
             this.modify_control.deactivate();


### PR DESCRIPTION
This force recomputation of offsets after each time the scrollbar is used.
