### PR TITLE
[9.0] Avoid zoom on set_value + define default zoom

### DIFF
--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -117,6 +117,7 @@ class GeoModel(models.BaseModel):
             res['geoengine_layers']['restricted_extent'] = restricted_extent
             default_extent = view.default_extent or DEFAULT_EXTENT
             res['geoengine_layers']['default_extent'] = default_extent
+            res['geoengine_layers']['default_zoom'] = view.default_zoom
             # TODO find why context in read does not work with webclient
             for layer in view.raster_layer_ids:
                 layer_dict = raster_obj.read(cursor, uid, layer.id)
@@ -167,6 +168,7 @@ class GeoModel(models.BaseModel):
         res['projection'] = view.projection
         res['restricted_extent'] = view.restricted_extent
         res['default_extent'] = view.default_extent
+        res['default_zoom'] = view.default_zoom
         return res
 
     def geo_search(self, cursor, uid, domain=None, geo_domain=None, offset=0,

--- a/base_geoengine/geo_view/ir_view.py
+++ b/base_geoengine/geo_view/ir_view.py
@@ -36,6 +36,9 @@ class IrUIView(models.Model):
         default='-123164.85222423, 5574694.9538936, 1578017.6490538,'
         ' 6186191.1800898'
     )
+    default_zoom = fields.Integer(
+        'Default map zoom',
+    )
     restricted_extent = fields.Char(
         'Restricted map extent', size=128,
     )

--- a/base_geoengine/geo_view/ir_view_view.xml
+++ b/base_geoengine/geo_view/ir_view_view.xml
@@ -14,6 +14,7 @@
                             <field name="projection"/>
                             <field name="restricted_extent" colspan="4"/>
                             <field name="default_extent" colspan="4"/>
+                            <field name="default_zoom"/>
                         </group>
                         <separator string="Vector (Active layers)" colspan="4"/>
                         <field name="vector_layer_ids" colspan="4" nolabel="1"/>

--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -109,24 +109,26 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
         });
     },
 
-    set_value: function(value) {
+    set_value: function(value, zoom=true) {
         this._super.apply(this, arguments);
         this.value = value;
         if (this.map) {
             var vl = this.map.getLayersByName(this.name)[0];
             vl.destroyFeatures();
+            var extent = this.default_extend;
             if (this.value) {
                 var features = this.format.read(this.value);
                 vl.addFeatures(features, {silent: true});
-                this.map.zoomToExtent(vl.getDataExtent());
-            } else {
-                this.map.zoomToExtent(this.default_extend);
+                extent = vl.getDataExtent();
+            }
+            if (zoom) {
+                this.map.zoomToExtent(extent);
             }
         }
     },
 
     on_ui_change: function() {
-        this.set_value(this.format.write(this._geometry));
+        this.set_value(this.format.write(this._geometry), zoom=false);
     },
 
     validate: function() {

--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -110,7 +110,9 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
         });
     },
 
-    set_value: function(value, zoom=true) {
+    set_value: function(value, zoom) {
+        zoom = (typeof zoom === 'undefined') ? true : zoom
+
         this._super.apply(this, arguments);
         this.value = value;
         if (this.map) {
@@ -132,7 +134,7 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
     },
 
     on_ui_change: function() {
-        this.set_value(this.format.write(this._geometry), zoom=false);
+        this.set_value(this.format.write(this._geometry), false);
     },
 
     validate: function() {

--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -101,6 +101,7 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
             self.geo_type = result.geo_type;
             self.projection = result.projection;
             self.default_extent = result.default_extent;
+            self.default_zoom = result.default_zoom;
             self.restricted_extent = result.restricted_extent;
             self.srid = result.srid;
             if (self.$el.is(':visible')){
@@ -123,6 +124,9 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
             }
             if (zoom) {
                 this.map.zoomToExtent(extent);
+                if (this.value && this.default_zoom) {
+                    this.map.zoomTo(this.default_zoom);
+                }
             }
         }
     },


### PR DESCRIPTION
This is a good improvement to geometry edition, it will avoid you several zoom outs you would have to do to restore the right zoom level you need to see everything you need.
