### PR TITLE
[8.0] geoengine_geoname_geocoder: new parent for wizard menu, buttons in footer

### DIFF
--- a/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
+++ b/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
@@ -15,8 +15,9 @@
                     <field name="add_to_encode" colspan="4" attrs="{'invisible': [('encode_all', '=', True)]}"/>
                     <newline/>
                     <footer>
-                        <button icon="gtk-cancel" special="cancel" string="Cancel"/>
-                        <button icon="gtk-ok" name="encode" string="Encode addresses" type="object"/>
+                        <button class="oe_hightlight" name="encode" string="Encode addresses" type="object"/>
+                        or
+                        <button class="oe_link" special="cancel" string="Cancel"/>
                     </footer>
                 </form>
             </field>

--- a/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
+++ b/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
@@ -24,6 +24,7 @@
         <record id="action_geonames_geocoder_wizard" model="ir.actions.act_window">
             <field name="name">Geolocalize addresses</field>
             <field name="type">ir.actions.act_window</field>
+            <field name="target">new</field>
             <field name="res_model">geoengine.geoname.encoder</field>
             <field name="view_mode">form</field>
             <field name="view_id" ref="geonames_geocoder_wizard"/>
@@ -32,7 +33,7 @@
         <menuitem
             name="Localize addresses from GeoNames"
             id="actiongeonames_geocoder_wizard_menu"
-            parent="base_geoengine.geoengine_base_menu"
+            parent="base_geoengine.geoengine_base_view_menu"
             action="action_geonames_geocoder_wizard"
             groups="base_geoengine.group_geoengine_admin"
             />

--- a/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
+++ b/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
@@ -9,14 +9,15 @@
             <field name="arch" type="xml">
                 <form string="Encode addresses from geonames">
                     <separator string="This wizard Geolocalize you addresses when possible. Look at log for details" colspan="4"/>
-                    <field name="encode_all" filename="name"/>
+                    <group>
+                        <field name="encode_all" filename="name"/>
+                    </group>
                     <field name="add_to_encode" colspan="4" attrs="{'invisible': [('encode_all', '=', True)]}"/>
                     <newline/>
-                    <group colspan="4" col="6">
-                        <label string=" " colspan="2"/>
+                    <footer>
                         <button icon="gtk-cancel" special="cancel" string="Cancel"/>
                         <button icon="gtk-ok" name="encode" string="Encode addresses" type="object"/>
-                    </group>
+                    </footer>
                 </form>
             </field>
         </record>

--- a/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
+++ b/geoengine_geoname_geocoder/wizard/bulk_encode_view.xml
@@ -15,7 +15,7 @@
                     <field name="add_to_encode" colspan="4" attrs="{'invisible': [('encode_all', '=', True)]}"/>
                     <newline/>
                     <footer>
-                        <button class="oe_hightlight" name="encode" string="Encode addresses" type="object"/>
+                        <button class="oe_highlight" name="encode" string="Encode addresses" type="object"/>
                         or
                         <button class="oe_link" special="cancel" string="Cancel"/>
                     </footer>


### PR DESCRIPTION
Fixes issue #36 
Changed 'parent' for menuitem which is calling partner selection wizard in geoengine_geoname_geocoder module. The same wizard is now called with target set to 'new', boolean 'encode_all' field is now in 'group' tags on wizard form, wizard buttons are now inside 'footer' tag.
![Result](https://cloud.githubusercontent.com/assets/450994/14826358/2d671946-0be6-11e6-8a98-617ad0d53c82.png)
