### PR TITLE
9.0 selection filter

### DIFF
--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -119,8 +119,11 @@ div.olClearMapItemInactive:hover {
     color: white;
 }
 #map_info_filter_selection {
-    position: absolute;
-    top: 40px;
+    cursor: pointer;
+    background-color: #337ab7;
+    vertical-align: middle;
+    text-align: center;
+    color: white;
 }
 
 #map_measurementbox {

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -31,6 +31,15 @@ div.olmap {
   height: 100%;
   width: 100%;
 }
+/*XXX*/
+.olHandlerBoxSelectFeature {
+    border: 2px solid red;
+    position: absolute;
+    background-color: white;
+    opacity: 0.50;
+    font-size: 1px;
+    filter: alpha(opacity=50);
+}
 
 div.olControlPanel {
     margin: 80px 10px;
@@ -67,47 +76,16 @@ div.olClearMapItemInactive:hover {
   width: 100%;
 }
 
-.olControlSelectSimple,
-.olControlSelectBox {
-    border-radius: 4px;
-    float: right;
-    display: block;
-    margin: 1px;
-    padding: 0;
-    color: white;
-    text-align: center;
-    font-size: 18px;
-    font-family: FontAwesome, Verdana;
-    height: 22px;
-    width:22px;
-    background: #130085; /* fallback for IE - IE6 requires background shorthand*/
-    background: rgba(0, 60, 136, 0.5);
-    filter: alpha(opacity=80);
+.olControlEditingToolbar .olControlSelectBoxItemInactive {
+    background-position: 0px -1px;
 }
 
-div.olControlSelectSimple:hover,
-div.olControlSelectBox:hover {
-    background: #130085; /* fallback for IE */
-    background: rgba(0, 60, 136, 0.7);
-    filter: alpha(opacity=100);
+.olControlEditingToolbar .olControlSelectBoxItemActive {
+    background-position: 0px -24px;
 }
 
-.olControlSelectSimple {
-    content: "\f245";
-}
-
-div.olControlSelectSimple:before {
-    font-family: FontAwesome, Verdana;
-    content: "\f245";
-}
-
-.olControlSelectBox {
-    content: "\f2ae";
-}
-
-div.olControlSelectBox:before {
-    font-family: FontAwesome, Verdana;
-    content: "\f2ae";
+.olDrowBox {
+    cursor: crosshair;
 }
 .map_overlay {
     position: absolute;

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -65,6 +65,7 @@ div.olClearMapItemInactive:hover {
 .olmap:fullscreen {
   height: 100%;
   width: 100%;
+}
 
 .olControlSelectSimple,
 .olControlSelectBox {

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -31,15 +31,6 @@ div.olmap {
   height: 100%;
   width: 100%;
 }
-/*XXX*/
-.olHandlerBoxSelectFeature {
-    border: 2px solid red;
-    position: absolute;
-    background-color: white;
-    opacity: 0.50;
-    font-size: 1px;
-    filter: alpha(opacity=50);
-}
 
 div.olControlPanel {
     margin: 80px 10px;

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -65,6 +65,48 @@ div.olClearMapItemInactive:hover {
 .olmap:fullscreen {
   height: 100%;
   width: 100%;
+
+.olControlSelectSimple,
+.olControlSelectBox {
+    border-radius: 4px;
+    float: right;
+    display: block;
+    margin: 1px;
+    padding: 0;
+    color: white;
+    text-align: center;
+    font-size: 18px;
+    font-family: FontAwesome, Verdana;
+    height: 22px;
+    width:22px;
+    background: #130085; /* fallback for IE - IE6 requires background shorthand*/
+    background: rgba(0, 60, 136, 0.5);
+    filter: alpha(opacity=80);
+}
+
+div.olControlSelectSimple:hover,
+div.olControlSelectBox:hover {
+    background: #130085; /* fallback for IE */
+    background: rgba(0, 60, 136, 0.7);
+    filter: alpha(opacity=100);
+}
+
+.olControlSelectSimple {
+    content: "\f245";
+}
+
+div.olControlSelectSimple:before {
+    font-family: FontAwesome, Verdana;
+    content: "\f245";
+}
+
+.olControlSelectBox {
+    content: "\f2ae";
+}
+
+div.olControlSelectBox:before {
+    font-family: FontAwesome, Verdana;
+    content: "\f2ae";
 }
 .map_overlay {
     position: absolute;

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -118,6 +118,11 @@ div.olClearMapItemInactive:hover {
     text-align: center;
     color: white;
 }
+#map_info_filter_selection {
+    position: absolute;
+    top: 40px;
+}
+
 #map_measurementbox {
         top: 18px;
         left: 160px;

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -88,7 +88,7 @@ var formatFeatureHTML = function(a, fields) {
  */
 var formatFeatureListHTML = function(features) {
     var str = [];
-    str.push(features.length + ' features selected');
+    str.push(features.getLength() + ' features selected');
     return str.join('<br />');
 };
 

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -88,8 +88,7 @@ var formatFeatureHTML = function(a, fields) {
  */
 var formatFeatureListHTML = function(features) {
     var str = [];
-    // TODO
-    str = ['multiple features selected'];
+    str.push(features.length + ' features selected');
     return str.join('<br />');
 };
 

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -88,7 +88,15 @@ var formatFeatureHTML = function(a, fields) {
  */
 var formatFeatureListHTML = function(features) {
     var str = [];
-    str.push(features.getLength() + ' features selected');
+    // count unique record selected through all features
+    var selected_ids = [];
+    features.forEach(function(x) {
+        var rec_id = x.get('attributes').id;
+        if (selected_ids.indexOf(rec_id) < 0) {
+            selected_ids.push(rec_id);
+        }
+    });
+    str.push(selected_ids.length + ' selected records');
     return str.join('<br />');
 };
 
@@ -547,10 +555,16 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             // div
             var info = [];
             var extent = dragBox.getGeometry().getExtent();
-            var vectorSource = self.vectorSources[0];
-            vectorSource.forEachFeatureIntersectingExtent(extent, function(feature) {
-                if (selectedFeatures.getArray().indexOf(feature) < 0) {
-                    selectedFeatures.push(feature);
+            var layerVectors = self.map.getLayers().item(1).getLayers();
+            layerVectors.forEach(function(lv) {
+                // enable selection only on visible layers
+                if (lv.getVisible()) {
+                    vectorSource = lv.getSource();
+                    vectorSource.forEachFeatureIntersectingExtent(extent, function(feature) {
+                        if (selectedFeatures.getArray().indexOf(feature) < 0) {
+                            selectedFeatures.push(feature);
+                        }
+                    });
                 }
             });
             self.update_info_box(selectedFeatures);

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -35,13 +35,13 @@ var DEFAULT_NUM_CLASSES = 5; // for choroplets only
 var LEGEND_MAX_ITEMS = 10;
 
 /**
- * Method: formatHTML
+ * Method: formatFeatureHTML
  * formats attributes into a string
  *
  * Parameters:
  * a - {Object}
  */
-var formatHTML = function(a, fields) {
+var formatFeatureHTML = function(a, fields) {
     var str = [];
     var oid = '';
     for (var key in a) {
@@ -77,6 +77,19 @@ var formatHTML = function(a, fields) {
         }
     }
     str.unshift(oid);
+    return str.join('<br />');
+};
+/**
+ * Method: formatFeatureListHTML
+ * formats attributes into a string
+ *
+ * Parameters:
+ * features - [Array]
+ */
+var formatFeatureListHTML = function(features) {
+    var str = [];
+    // TODO
+    str = ['multiple features selected'];
     return str.join('<br />');
 };
 
@@ -506,13 +519,15 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         });
         selectClick.on('select', function(e) {
             var features = e.target.getFeatures();
-            if (features.getLength() > 0){
+            if (features.getLength() == 1){
                 var attributes = features.item(0).get('attributes');
-                $("#map_info").html(formatHTML(attributes, self.fields_view.fields));
+                $("#map_info").html(formatFeatureHTML(attributes, self.fields_view.fields));
                 $("#map_infobox").off().click(function() {
                     self.open_record(features.item(0));
                 });
                 $("#map_infobox").show();
+            } else if (features.getLength() > 1) {
+                $("#map_info").html(formatFeatureListHTML(features));
             } else {
                 $("#map_infobox").hide();
             }

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -210,7 +210,6 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
      */
     createVectorLayer: function(cfg, data) {
         var self = this;
-        var features = [];
         var geostat = null;
         var vectorSource = new ol.source.Vector({
         });
@@ -532,6 +531,9 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 $("#map_info").html(formatFeatureListHTML(features));
                 $("#map_info_filter_selection").show();
                 $("#map_infobox").show();
+                $("#map_infobox").off().click(function() {
+                    self.filter_selection(features);
+                });
             } else {
                 $("#map_infobox").hide();
             }
@@ -592,21 +594,14 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             self.render_map();
         });
     },
-    filter_selection: function() {
-        var selectedFeatures = [];
-        for (var l in this.map.layers) {
-            var layer = this.map.layers[l];
-            if (layer.selectedFeatures && layer.selectedFeatures.length > 0) {
-                selectedFeatures = layer.selectedFeatures;
-                break;
-            }
-        }
-        var selected_ids = selectedFeatures.map(function(x) {return x.data.id;});
+    filter_selection: function(features) {
+        var selected_ids = [];
+        features.forEach(function (x) {selected_ids.push(x.get('attributes').id);});
         var selection_domain = [['id', 'in', selected_ids]];
         var searchview = this.ViewManager.searchview
         searchview.query.add({
-            category: _t("Geo selection"),
-            values: {label: _t("Geo selection")},
+            category: _lt("Geo selection"),
+            values: {label: _lt("Geo selection")},
             icon: '$', // world globe in mnmlicons
             field: {
               get_context: function () { },

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -211,10 +211,13 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
     createVectorLayer: function(cfg, data) {
         var self = this;
         var geostat = null;
-        var vectorSource = new ol.source.Vector({
-        });
-        if (data.length == 0)
-            return vl
+        var vectorSource = new ol.source.Vector({});
+        if (data.length == 0) {
+            return new ol.layer.Vector({
+                source: vectorSource,
+                title: cfg.name,
+            })
+        }
         _.each(data, function(item) {
             var attributes = _.clone(item);
             _.each(_.keys(self.geometry_columns), function(item) {
@@ -478,8 +481,8 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
 
         // zoom to data extent
         //map.zoomTo
-        var extent = vectorLayers[0].getSource().getExtent();
-        if (extent) {
+        if (data.length) {
+            var extent = vectorLayers[0].getSource().getExtent();
             this.zoom_to_extent_ctrl.extent_ = extent;
             this.zoom_to_extent_ctrl.changed();
             map.getView().fit(extent, map.getSize());

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -607,7 +607,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         searchview.query.add({
             category: _lt("Geo selection"),
             values: {label: _lt("Geo selection")},
-            icon: '$', // world globe in mnmlicons
+            icon: 'fa-map-o',
             field: {
               get_context: function () { },
               get_domain: function() {return selection_domain;},

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -522,12 +522,15 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             if (features.getLength() == 1){
                 var attributes = features.item(0).get('attributes');
                 $("#map_info").html(formatFeatureHTML(attributes, self.fields_view.fields));
+                $("#map_info_filter_selection").hide();
                 $("#map_infobox").off().click(function() {
                     self.open_record(features.item(0));
                 });
                 $("#map_infobox").show();
             } else if (features.getLength() > 1) {
                 $("#map_info").html(formatFeatureListHTML(features));
+                $("#map_info_filter_selection").show();
+                $("#map_infobox").show();
             } else {
                 $("#map_infobox").hide();
             }
@@ -588,6 +591,29 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         // Wait for element to be rendered before adding the map
         core.bus.on('DOM_updated', self.view_manager.is_in_DOM, function () {
             self.render_map();
+        });
+    },
+    filter_selection: function() {
+        selectedFeatures = [];
+        for (var l in this.map.layers) {
+            var layer = this.map.layers[l];
+            if (layer.selectedFeatures && layer.selectedFeatures.length > 0) {
+                selectedFeatures = layer.selectedFeatures;
+                break;
+            }
+        }
+        selected_ids = selectedFeatures.map(function(x) {return x.data.id;});
+        selection_domain = [['id', 'in', selected_ids]];
+        searchview = this.ViewManager.searchview
+        searchview.query.add({
+            category: _t("Geo selection"),
+            values: {label: _t("Geo selection")},
+            icon: '$', // world globe in mnmlicons
+            field: {
+              get_context: function () { },
+              get_domain: function() {return selection_domain;},
+              get_groupby: function () { }
+            }
         });
     },
     /* XXX

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -115,13 +115,15 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             select: new OpenLayers.Control.SelectFeature(
                 {selectedFeatures:[]},
                 {
-                    clickout: false, toggle: false,
+                    // displayClass used to find it
+                    displayClass: 'olSelectFeature',
+                    clickout: true, toggle: false,
                     multiple: false,
                     toggleKey: "ctrlKey",
                     multipleKey: "shiftKey", box: false
                 }
             )
-        }*/
+        };*/
     },
     load_view: function(context) {
         var self = this;
@@ -216,7 +218,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         if (data.length == 0)
             return vl
         _.each(data, function(item) {
-            attributes = _.clone(item);
+            var attributes = _.clone(item);
             _.each(_.keys(self.geometry_columns), function(item) {
                 delete attributes[item];
             });
@@ -493,7 +495,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         }
         /* XXX
          for(var key in this.selectFeatureControls) {
-            ctrl = this.selectFeatureControls[key];
+            var ctrl = this.selectFeatureControls[key];
             ctrl.setLayer(this.vectorLayers);
             // ensure map is define on controler and handler
             ctrl.map = map
@@ -563,22 +565,20 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                     this.zoom_to_extent_ctrl
                 ]),
             });
-            /* XXX
-                    new OpenLayers.Control.Button({
-                        displayClass: 'olControlSelectSimple',
-                        type: OpenLayers.Control.TYPE_BUTTON,
-                        trigger: this.enableSelectControlSimple
-                    }),
-                    new OpenLayers.Control.Button({
-                        displayClass: 'olControlSelectBox',
-                        type: OpenLayers.Control.TYPE_BUTTON,
-                        trigger: this.enableSelectControlBox
-                    })*/
             var layerSwitcher = new ol.control.LayerSwitcher({});
             map.addControl(layerSwitcher);
-            /* for(var key in this.selectFeatureControls) {
-                map.addControls(this.selectFeatureControls[key]);
-            }*/
+            /*
+            map.addControl(this.selectFeatureControls.selectHover);
+            map.addControl(this.selectFeatureControls.select);
+            // create box handler as we want it to be activable
+            this.selectFeatureControls.select.handlers.box = new OpenLayers.Handler.Box(
+                this.selectFeatureControls.select, {done: this.selectFeatureControls.select.selectBox},
+                {boxDivClassName: "olHandlerBoxSelectFeature"}
+            );
+            this.selectFeatureControls.select.setMap(map);
+            this.selectFeatureControls.select.handlers.map = map;
+            map.addControl(new OpenLayers.Control.ToolPanel());
+            */
             this.map = map;
             this.register_interaction();
         }
@@ -594,7 +594,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         });
     },
     filter_selection: function() {
-        selectedFeatures = [];
+        var selectedFeatures = [];
         for (var l in this.map.layers) {
             var layer = this.map.layers[l];
             if (layer.selectedFeatures && layer.selectedFeatures.length > 0) {
@@ -602,9 +602,9 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 break;
             }
         }
-        selected_ids = selectedFeatures.map(function(x) {return x.data.id;});
-        selection_domain = [['id', 'in', selected_ids]];
-        searchview = this.ViewManager.searchview
+        var selected_ids = selectedFeatures.map(function(x) {return x.data.id;});
+        var selection_domain = [['id', 'in', selected_ids]];
+        var searchview = this.ViewManager.searchview
         searchview.query.add({
             category: _t("Geo selection"),
             values: {label: _t("Geo selection")},
@@ -616,13 +616,6 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             }
         });
     },
-    /* XXX
-    enableSelectControlBox: function() {
-        this.selectFeatureControls['select'].box = true;
-    },
-    enableSelectControlSimple: function() {
-        this.selectFeatureControls['select'].box = false;
-    },*/
 
     open_record: function (feature, options) {
 

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -522,6 +522,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             if (features.getLength() == 1){
                 var attributes = features.item(0).get('attributes');
                 $("#map_info").html(formatFeatureHTML(attributes, self.fields_view.fields));
+                $("#map_info_open").show();
                 $("#map_info_filter_selection").hide();
                 $("#map_infobox").off().click(function() {
                     self.open_record(features.item(0));
@@ -529,11 +530,12 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 $("#map_infobox").show();
             } else if (features.getLength() > 1) {
                 $("#map_info").html(formatFeatureListHTML(features));
+                $("#map_info_open").hide();
                 $("#map_info_filter_selection").show();
-                $("#map_infobox").show();
                 $("#map_infobox").off().click(function() {
                     self.filter_selection(features);
                 });
+                $("#map_infobox").show();
             } else {
                 $("#map_infobox").hide();
             }

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -95,6 +95,20 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         this.view_type = 'geoengine'
         this.geometry_columns = {};
         this.overlaysGroup = null;
+        /* XXX
+         this.selectFeatureControls = {
+            selectHover: new OpenLayers.Control.SelectFeature(
+                {selectedFeatures:[]}, {hover: true, highlightOnly: true}),
+            select: new OpenLayers.Control.SelectFeature(
+                {selectedFeatures:[]},
+                {
+                    clickout: false, toggle: false,
+                    multiple: false,
+                    toggleKey: "ctrlKey",
+                    multipleKey: "shiftKey", box: false
+                }
+            )
+        }*/
     },
     load_view: function(context) {
         var self = this;
@@ -464,6 +478,15 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             }
             self.dataset.ids = ids;
         }
+        /* XXX
+         for(var key in this.selectFeatureControls) {
+            ctrl = this.selectFeatureControls[key];
+            ctrl.setLayer(this.vectorLayers);
+            // ensure map is define on controler and handler
+            ctrl.map = map
+            ctrl.handlers.feature.map = map
+            ctrl.activate();
+        }*/
     },
 
     view_loading: function(fv) {
@@ -522,8 +545,22 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                     this.zoom_to_extent_ctrl
                 ]),
             });
+            /* XXX
+                    new OpenLayers.Control.Button({
+                        displayClass: 'olControlSelectSimple',
+                        type: OpenLayers.Control.TYPE_BUTTON,
+                        trigger: this.enableSelectControlSimple
+                    }),
+                    new OpenLayers.Control.Button({
+                        displayClass: 'olControlSelectBox',
+                        type: OpenLayers.Control.TYPE_BUTTON,
+                        trigger: this.enableSelectControlBox
+                    })*/
             var layerSwitcher = new ol.control.LayerSwitcher({});
             map.addControl(layerSwitcher);
+            /* for(var key in this.selectFeatureControls) {
+                map.addControls(this.selectFeatureControls[key]);
+            }*/
             this.map = map;
             this.register_interaction();
         }
@@ -538,6 +575,14 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             self.render_map();
         });
     },
+    /* XXX
+    enableSelectControlBox: function() {
+        this.selectFeatureControls['select'].box = true;
+    },
+    enableSelectControlSimple: function() {
+        this.selectFeatureControls['select'].box = false;
+    },*/
+
     open_record: function (feature, options) {
 
         var attributes = feature.get('attributes');

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -107,22 +107,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         this.view_type = 'geoengine'
         this.geometry_columns = {};
         this.overlaysGroup = null;
-        /* XXX
-         this.selectFeatureControls = {
-            selectHover: new OpenLayers.Control.SelectFeature(
-                {selectedFeatures:[]}, {hover: true, highlightOnly: true}),
-            select: new OpenLayers.Control.SelectFeature(
-                {selectedFeatures:[]},
-                {
-                    // displayClass used to find it
-                    displayClass: 'olSelectFeature',
-                    clickout: true, toggle: false,
-                    multiple: false,
-                    toggleKey: "ctrlKey",
-                    multipleKey: "shiftKey", box: false
-                }
-            )
-        };*/
+        this.vectorSources = [];
     },
     load_view: function(context) {
         var self = this;
@@ -252,6 +237,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 elLegend.hide();
             }
         });
+        this.vectorSources.push(vectorSource);
         return lv;
     },
 
@@ -494,15 +480,6 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             }
             self.dataset.ids = ids;
         }
-        /* XXX
-         for(var key in this.selectFeatureControls) {
-            var ctrl = this.selectFeatureControls[key];
-            ctrl.setLayer(this.vectorLayers);
-            // ensure map is define on controler and handler
-            ctrl.map = map
-            ctrl.handlers.feature.map = map
-            ctrl.activate();
-        }*/
     },
 
     view_loading: function(fv) {
@@ -514,6 +491,29 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         return $.when();
     },
 
+    update_info_box: function(features) {
+        var self = this;
+        if (features.getLength() == 1){
+            var attributes = features.item(0).get('attributes');
+            $("#map_info").html(formatFeatureHTML(attributes, this.fields_view.fields));
+            $("#map_info_open").show();
+            $("#map_info_filter_selection").hide();
+            $("#map_infobox").off().click(function() {
+                self.open_record(features.item(0));
+            });
+            $("#map_infobox").show();
+        } else if (features.getLength() > 1) {
+            $("#map_info").html(formatFeatureListHTML(features));
+            $("#map_info_open").hide();
+            $("#map_info_filter_selection").show();
+            $("#map_infobox").off().click(function() {
+                self.filter_selection(features);
+            });
+            $("#map_infobox").show();
+        } else {
+            $("#map_infobox").hide();
+        }
+    },
     register_interaction: function(){
         var self = this;
         // select interaction working on "click"
@@ -522,32 +522,41 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         });
         selectClick.on('select', function(e) {
             var features = e.target.getFeatures();
-            if (features.getLength() == 1){
-                var attributes = features.item(0).get('attributes');
-                $("#map_info").html(formatFeatureHTML(attributes, self.fields_view.fields));
-                $("#map_info_open").show();
-                $("#map_info_filter_selection").hide();
-                $("#map_infobox").off().click(function() {
-                    self.open_record(features.item(0));
-                });
-                $("#map_infobox").show();
-            } else if (features.getLength() > 1) {
-                $("#map_info").html(formatFeatureListHTML(features));
-                $("#map_info_open").hide();
-                $("#map_info_filter_selection").show();
-                $("#map_infobox").off().click(function() {
-                    self.filter_selection(features);
-                });
-                $("#map_infobox").show();
-            } else {
-                $("#map_infobox").hide();
-            }
+            self.update_info_box(features);
           });
 
         // select interaction working on "pointermove"
         var selectPointerMove = new ol.interaction.Select({
           condition: ol.events.condition.pointerMove
         });
+
+        // a DragBox interaction used to select features by drawing boxes
+        var dragBox = new ol.interaction.DragBox({
+          condition: ol.events.condition.shiftKeyOnly,
+          style: new ol.style.Style({
+            stroke: new ol.style.Stroke({
+              color: [0, 0, 255, 1]
+            })
+          })
+        });
+
+        var selectedFeatures = selectClick.getFeatures();
+        dragBox.on('boxend', function(e) {
+            // features that intersect the box are added to the collection of
+            // selected features, and their names are displayed in the "info"
+            // div
+            var info = [];
+            var extent = dragBox.getGeometry().getExtent();
+            var vectorSource = self.vectorSources[0];
+            vectorSource.forEachFeatureIntersectingExtent(extent, function(feature) {
+                if (selectedFeatures.getArray().indexOf(feature) < 0) {
+                    selectedFeatures.push(feature);
+                }
+            });
+            self.update_info_box(selectedFeatures);
+        });
+
+        this.map.addInteraction(dragBox);
         this.map.addInteraction(selectClick);
         this.map.addInteraction(selectPointerMove);
     },
@@ -573,18 +582,6 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             });
             var layerSwitcher = new ol.control.LayerSwitcher({});
             map.addControl(layerSwitcher);
-            /*
-            map.addControl(this.selectFeatureControls.selectHover);
-            map.addControl(this.selectFeatureControls.select);
-            // create box handler as we want it to be activable
-            this.selectFeatureControls.select.handlers.box = new OpenLayers.Handler.Box(
-                this.selectFeatureControls.select, {done: this.selectFeatureControls.select.selectBox},
-                {boxDivClassName: "olHandlerBoxSelectFeature"}
-            );
-            this.selectFeatureControls.select.setMap(map);
-            this.selectFeatureControls.select.handlers.map = map;
-            map.addControl(new OpenLayers.Control.ToolPanel());
-            */
             this.map = map;
             this.register_interaction();
         }

--- a/base_geoengine/static/src/xml/geoengine.xml
+++ b/base_geoengine/static/src/xml/geoengine.xml
@@ -7,8 +7,8 @@
           <span class="fa fa-edit"/>
         </div>
         <div id="map_info"/>
-        <div id="map_info_filter_selection">
-          <span class="fa fa-filter">Filter selection</span>
+        <div id="map_info_filter_selection" class="oe_button">
+          <span class="fa fa-filter"> Filter selection</span>
         </div>
         <div id="map_legend" class="ol-control"/>
       </div>

--- a/base_geoengine/static/src/xml/geoengine.xml
+++ b/base_geoengine/static/src/xml/geoengine.xml
@@ -6,10 +6,10 @@
         <div id="map_info_open">
           <span class="fa fa-edit"/>
         </div>
-        <div id="map_info"/>
-        <div id="map_info_filter_selection" class="oe_button">
+        <div id="map_info_filter_selection">
           <span class="fa fa-filter"> Filter selection</span>
         </div>
+        <div id="map_info"/>
         <div id="map_legend" class="ol-control"/>
       </div>
       <div id="map_measurementbox" class="map_overlay"/>

--- a/base_geoengine/static/src/xml/geoengine.xml
+++ b/base_geoengine/static/src/xml/geoengine.xml
@@ -7,6 +7,9 @@
           <span class="fa fa-edit"/>
         </div>
         <div id="map_info"/>
+        <div id="map_info_filter_selection">
+          <span class="fa fa-filter">Filter selection</span>
+        </div>
         <div id="map_legend" class="ol-control"/>
       </div>
       <div id="map_measurementbox" class="map_overlay"/>


### PR DESCRIPTION
This is a port of the selection filter made for geoengine in odoo 8.0 on odoo 9.0 with OL3
- First commits are cherry-picked from https://github.com/OCA/geospatial/pull/105
- Instead of having a button in tool box, dragbox is usable by pressing the SHIFT key.
- It supports multi vector layer selection.
