### PR TITLE
Fix map size error when open record in a fullscreen map.

### DIFF
--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -1,5 +1,8 @@
 /* OpenLayers Style */
 div.olmap {
+    /* For map size recomputation we have to define this size. */
+    height: 100%;
+    width: 100%;
     z-index: 0;
     padding: 0 !important;
     margin: 0 !important;

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -455,6 +455,14 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         if (extent) {
             this.zoom_to_extent_ctrl.extent_ = extent;
             this.zoom_to_extent_ctrl.changed();
+
+            // When user quit fullscreen map, the size is set to undefined
+            // So we have to check this and recompute the size.
+            var size = map.getSize();
+            if ( size === undefined ){
+                map.updateSize();
+                size = map.getSize();
+            }
             map.getView().fit(extent, map.getSize());
 
             var ids = [];


### PR DESCRIPTION
Bug was: Open map view full screen, open record form view (by clicking on a point), and switch to map view again => JS error because the map object size is undefined
