### PR TITLE
[10.0] base_geoengine fix and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ addons:
 
 language: python
 
+before_script:
+  - createdb openerp_test
+  - psql -U postgres -d openerp_test -c "create extension postgis"
+  - psql -U postgres -d openerp_test -c "create extension postgis_topology"
+
 python:
   - "2.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ sudo: false
 cache: pip
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
+      - postgresql-9.6-postgis-2.3 postgis # because travis doesn't know which one to install
 
 language: python
 

--- a/base_geoengine/README.rst
+++ b/base_geoengine/README.rst
@@ -56,6 +56,7 @@ Contributors
 * Sandy Carter <sandy.carter@savoirfairelinux.com>
 * Vincent Renaville <vincent.renaville@camptocamp.com>
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
+* Benjamin Willig <benjamin.willig@acsone.eu>
 
 Maintainer
 ----------

--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Geospatial support for Odoo',
-    'version': '10.0.1.0.0',
+    'version': '10.0.2.0.0',
     'category': 'GeoBI',
     'author': "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     'license': 'AGPL-3',

--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -23,8 +23,11 @@
      'security/ir.model.access.csv',
  ],
  'external_dependencies': {
-     'python': ['shapely',
-                'geojson'],
+     'python': [
+        'shapely',
+        'geojson',
+        'simplejson'
+     ],
  },
  'qweb': ["static/src/xml/geoengine.xml"],
  'installable': True,

--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -8,12 +8,11 @@
     'category': 'GeoBI',
     'author': "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
-    'website': 'http://openerp.camptocamp.com',
+    'website': 'https://github.com/OCA/geospatial',
     'depends': [
         'base',
         'web'
     ],
-    'init_xml': [],
     'data': [
         'security/data.xml',
         'views/base_geoengine_view.xml',
@@ -30,7 +29,9 @@
             'simplejson'
         ],
     },
-    'qweb': ["static/src/xml/geoengine.xml"],
+    'qweb': [
+        'static/src/xml/geoengine.xml',
+    ],
     'installable': True,
     'pre_init_hook': 'init_postgis',
 }

--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -2,34 +2,35 @@
 # Copyright 2011-2015 Nicolas Bessi (Camptocamp SA)
 # Copyright 2016 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-{'name': 'Geospatial support for Odoo',
- 'version': '10.0.1.0.0',
- 'category': 'GeoBI',
- 'author': "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
- 'license': 'AGPL-3',
- 'website': 'http://openerp.camptocamp.com',
- 'depends': [
-     'base',
-     'web'
- ],
- 'init_xml': [],
- 'data': [
-     'security/data.xml',
-     'views/base_geoengine_view.xml',
-     'geo_ir/ir_model_view.xml',
-     'geo_view/ir_view_view.xml',
-     'geo_view/geo_raster_layer_view.xml',
-     'geo_view/geo_vector_layer_view.xml',
-     'security/ir.model.access.csv',
- ],
- 'external_dependencies': {
-     'python': [
-        'shapely',
-        'geojson',
-        'simplejson'
-     ],
- },
- 'qweb': ["static/src/xml/geoengine.xml"],
- 'installable': True,
- 'pre_init_hook': 'init_postgis',
- }
+{
+    'name': 'Geospatial support for Odoo',
+    'version': '10.0.1.0.0',
+    'category': 'GeoBI',
+    'author': "Camptocamp,ACSONE SA/NV,Odoo Community Association (OCA)",
+    'license': 'AGPL-3',
+    'website': 'http://openerp.camptocamp.com',
+    'depends': [
+        'base',
+        'web'
+    ],
+    'init_xml': [],
+    'data': [
+        'security/data.xml',
+        'views/base_geoengine_view.xml',
+        'geo_ir/ir_model_view.xml',
+        'geo_view/ir_view_view.xml',
+        'geo_view/geo_raster_layer_view.xml',
+        'geo_view/geo_vector_layer_view.xml',
+        'security/ir.model.access.csv',
+    ],
+    'external_dependencies': {
+        'python': [
+            'shapely',
+            'geojson',
+            'simplejson'
+        ],
+    },
+    'qweb': ["static/src/xml/geoengine.xml"],
+    'installable': True,
+    'pre_init_hook': 'init_postgis',
+}

--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -184,6 +184,30 @@ class GeoLine(GeoField):
     type = 'geo_line'
     geo_type = 'LINESTRING'
 
+    @classmethod
+    def from_points(cls, cr, point1, point2):
+        """
+        Converts given points in parameter to a line.
+        :param cr: DB cursor
+        :param point1: Point (BaseGeometry)
+        :param point2: Point (BaseGeometry)
+        :return: LINESTRING HEX
+        """
+        sql = """
+        SELECT
+            ST_MakeLine(
+                ST_GeomFromText(%(wkt1)s, 4326),
+                ST_GeomFromText(%(wkt2)s, 4326)
+            )
+        """
+        cr.execute(sql, {
+            'wkt1': point1.wkt,
+            'wkt2': point2.wkt,
+            'srid': cls._slots['srid'],
+        })
+        res = cr.fetchone()
+        return cls.load_geo(res[0])
+
 
 class GeoMultiLine(GeoField):
     """Field for POSTGIS geometry MultiLine type"""

--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -198,13 +198,13 @@ class GeoLine(GeoField):
         :param cr: DB cursor
         :param point1: Point (BaseGeometry)
         :param point2: Point (BaseGeometry)
-        :return: LINESTRING HEX
+        :return: LINESTRING Object
         """
         sql = """
         SELECT
             ST_MakeLine(
-                ST_GeomFromText(%(wkt1)s, 4326),
-                ST_GeomFromText(%(wkt2)s, 4326)
+                ST_GeomFromText(%(wkt1)s, %(srid)s),
+                ST_GeomFromText(%(wkt2)s, %(srid)s)
             )
         """
         cr.execute(sql, {

--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -192,12 +192,13 @@ class GeoLine(GeoField):
     geo_type = 'LINESTRING'
 
     @classmethod
-    def from_points(cls, cr, point1, point2):
+    def from_points(cls, cr, point1, point2, srid=None):
         """
         Converts given points in parameter to a line.
         :param cr: DB cursor
         :param point1: Point (BaseGeometry)
         :param point2: Point (BaseGeometry)
+        :param srid: SRID
         :return: LINESTRING Object
         """
         sql = """
@@ -210,7 +211,7 @@ class GeoLine(GeoField):
         cr.execute(sql, {
             'wkt1': point1.wkt,
             'wkt2': point2.wkt,
-            'srid': cls._slots['srid'],
+            'srid': srid or cls._slots['srid'],
         })
         res = cr.fetchone()
         return cls.load_geo(res[0])

--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -64,8 +64,15 @@ class GeoField(Field):
         return val
 
     def convert_to_record(self, value, record):
-        if value:
-            return self.load_geo(value)
+        if not value:
+            return False
+        if isinstance(value, str):
+            # Geometry object hexcode from cache
+            shape = self.load_geo(value)
+        else:
+            # Might be unicode containing dict
+            shape = convert.value_to_shape(value)
+        return shape
 
     def convert_to_read(self, value, record, use_name_get=True):
         if not isinstance(value, BaseGeometry):

--- a/base_geoengine/geo_db.py
+++ b/base_geoengine/geo_db.py
@@ -2,9 +2,9 @@
 # Copyright 2011-2012 Nicolas Bessi (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 """Helper to setup Postgis"""
-from openerp.exceptions import MissingError
-
 import logging
+
+from odoo.exceptions import MissingError
 
 logger = logging.getLogger('geoengine.sql')
 

--- a/base_geoengine/geo_ir/ir_model_view.xml
+++ b/base_geoengine/geo_ir/ir_model_view.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-        <record model="ir.ui.view" id="view_model_fields_form_geo">
-            <!-- must be unique in this module. -->
-            <field name="name">ir.model.fields.form.geo</field>
-            <field name="model">ir.model.fields</field>
-            <field name="inherit_id" ref="base.view_model_fields_form"/>
-            <field name="arch" type="xml">
-                <sheet position="inside">
-                      <group>
-                          <!-- nasty attrs but ilike operator does not work as expected -->
-                          <field name="srid"
-                                 attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
-                          <field name="geo_type"
-                                 attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
-                          <field name="dim"
-                                 attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
-                          <field name="gist_index"
-                                 attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
-                      </group>
-                </sheet>
-            </field>
-        </record>
-    </data>
-</openerp>
+<odoo>
+
+    <record model="ir.ui.view" id="view_model_fields_form_geo">
+        <!-- must be unique in this module. -->
+        <field name="name">ir.model.fields.form.geo</field>
+        <field name="model">ir.model.fields</field>
+        <field name="inherit_id" ref="base.view_model_fields_form"/>
+        <field name="arch" type="xml">
+            <sheet position="inside">
+                  <group>
+                      <!-- nasty attrs but ilike operator does not work as expected -->
+                      <field name="srid"
+                             attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
+                      <field name="geo_type"
+                             attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
+                      <field name="dim"
+                             attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
+                      <field name="gist_index"
+                             attrs="{'readonly': [('ttype', 'not in', ['geo_polygon', 'geo_multi_polygon', 'geo_point', 'geo_multi_point', 'geo_line', 'geo_multi_line'])]}"/>
+                  </group>
+            </sheet>
+        </field>
+    </record>
+
+</odoo>

--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -42,12 +42,13 @@ class GeoModel(models.BaseModel):
         res = super(GeoModel, self)._auto_init()
         column_data = self._select_column_data()
         for f_name, geo_field in geo_fields.iteritems():
-            # XXX check if not computed field
-            if not geo_field.compute:
-                fct = geo_field.create_geo_column
-                if f_name in column_data:
-                    fct = geo_field.update_geo_column
-                fct(cr, f_name, self._table, self._name)
+            # XXX check if not computed stored field
+            if geo_field.compute and not geo_field.store:
+                continue
+            fct = geo_field.create_geo_column
+            if f_name in column_data:
+                fct = geo_field.update_geo_column
+            fct(cr, f_name, self._table, self._name)
         return res
 
     @api.model

--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -42,7 +42,6 @@ class GeoModel(models.BaseModel):
         res = super(GeoModel, self)._auto_init()
         column_data = self._select_column_data()
         for f_name, geo_field in geo_fields.iteritems():
-            # XXX check if not computed stored field
             if geo_field.compute and not geo_field.store:
                 continue
             fct = geo_field.create_geo_column

--- a/base_geoengine/geo_view/geo_raster_layer.py
+++ b/base_geoengine/geo_view/geo_raster_layer.py
@@ -35,7 +35,7 @@ class GeoRasterLayer(models.Model):
     url = fields.Char('Service URL', size=1024)
 
     # technical field to display or not wmts options
-    is_wmts = fields.Boolean(compute='_get_is_wmts')
+    is_wmts = fields.Boolean(compute='_compute_is_wmts')
     # wmts options
     matrix_set = fields.Char("matrixSet")
     format_suffix = fields.Char("formatSuffix", help="eg. png")
@@ -56,7 +56,7 @@ class GeoRasterLayer(models.Model):
     )
 
     # technical field to display or not layer type
-    has_type = fields.Boolean(compute='_get_has_type')
+    has_type = fields.Boolean(compute='_compute_has_type')
     type_id = fields.Many2one(
         'geoengine.raster.layer.type', "Layer",
         domain="[('service', '=', raster_type)]"
@@ -73,17 +73,18 @@ class GeoRasterLayer(models.Model):
         required=True)
     use_to_edit = fields.Boolean('Use to edit')
 
-    @api.one
+    @api.multi
     @api.depends('raster_type', 'is_wmts')
-    def _get_has_type(self):
-        self.has_type = self.raster_type == 'is_wmts'
+    def _compute_has_type(self):
+        for rec in self:
+            rec.has_type = rec.raster_type == 'is_wmts'
 
-    @api.one
+    @api.multi
     @api.depends('raster_type')
-    def _get_is_wmts(self):
-        self.is_wmts = self.raster_type == 'wmts'
+    def _compute_is_wmts(self):
+        for rec in self:
+            rec.is_wmts = rec.raster_type == 'wmts'
 
-    @api.one
     @api.onchange('raster_type')
     def onchange_set_wmts_options(self):
         """ Abstract method for WMTS modules to set default options """

--- a/base_geoengine/geo_view/geo_raster_layer_view.xml
+++ b/base_geoengine/geo_view/geo_raster_layer_view.xml
@@ -1,73 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-        <record model="ir.ui.view" id="geo_raster_view_form">
-            <field name="name">geoengine.raster.layer.form</field>
-            <field name="model">geoengine.raster.layer</field>
-            <field name="arch" type="xml">
-                <form string="Raster Layer View">
-                    <group string="General" col="4">
-                        <field name="name" colspan="4"/>
-                        <field name="view_id"/>
-                        <field name="raster_type"/>
-                        <field name="sequence"/>
-                        <field name="overlay"/>
-                        <field name="use_to_edit" colspan="4"/>
-                        <field name="url" colspan="4" widget="url" attrs="{'required': [('is_wmts', '=', True)]}"/>
-                    </group>
-                    <field name="is_wmts" invisible="1"/>
-                    <group string="WMTS options"
-                           attrs="{'invisible': [('is_wmts', '=', False)]}"
-                           colspan="4">
-                      <field name="matrix_set" attrs="{'required': [('is_wmts', '=', True)]}"/>
-                      <field name="format_suffix"/>
-                      <field name="request_encoding"/>
-                      <field name="projection"/>
-                      <field name="units"/>
-                      <field name="resolutions"/>
-                      <field name="max_extent"/>
-                      <field name="server_resolutions"/>
-                      <field name="dimensions"/>
-                      <field name="params"/>
-                    </group>
-                    <field name="has_type" invisible="1"/>
-                    <group string="Layer data"
-                           attrs="{'invisible': [('has_type', '=', False)]}"
-                           colspan="4">
-                      <field name="type_id" widget="selection" attrs="{'required': [('has_type', '=', True)]}"/>
-                    </group>
-                    <group string="Odoo layer data (Not implemented)"
-                           attrs="{'invisible': [('raster_type', '!=', 'odoo')]}"
-                           colspan="4">
-                        <field name="field_id"/>
-                    </group>
-                </form>
-            </field>
-        </record>
+<odoo>
 
-        <record model="ir.ui.view" id="geo_raster_view_tree">
-            <field name="name">geoengine.raster.layer.tree</field>
-            <field name="model">geoengine.raster.layer</field>
-            <field name="arch" type="xml">
-                <tree string="Raster">
-                    <field name="name" select="1"/>
-                    <field name="raster_type" select="1"/>
+    <record model="ir.ui.view" id="geo_raster_view_form">
+        <field name="name">geoengine.raster.layer.form</field>
+        <field name="model">geoengine.raster.layer</field>
+        <field name="arch" type="xml">
+            <form string="Raster Layer View">
+                <group string="General" col="4">
+                    <field name="name" colspan="4"/>
+                    <field name="view_id"/>
+                    <field name="raster_type"/>
                     <field name="sequence"/>
-                    <field name="overlay" select="1"/>
-                </tree>
-            </field>
-        </record>
+                    <field name="overlay"/>
+                    <field name="use_to_edit" colspan="4"/>
+                    <field name="url" colspan="4" widget="url" attrs="{'required': [('is_wmts', '=', True)]}"/>
+                </group>
+                <field name="is_wmts" invisible="1"/>
+                <group string="WMTS options"
+                       attrs="{'invisible': [('is_wmts', '=', False)]}"
+                       colspan="4">
+                  <field name="matrix_set" attrs="{'required': [('is_wmts', '=', True)]}"/>
+                  <field name="format_suffix"/>
+                  <field name="request_encoding"/>
+                  <field name="projection"/>
+                  <field name="units"/>
+                  <field name="resolutions"/>
+                  <field name="max_extent"/>
+                  <field name="server_resolutions"/>
+                  <field name="dimensions"/>
+                  <field name="params"/>
+                </group>
+                <field name="has_type" invisible="1"/>
+                <group string="Layer data"
+                       attrs="{'invisible': [('has_type', '=', False)]}"
+                       colspan="4">
+                  <field name="type_id" widget="selection" attrs="{'required': [('has_type', '=', True)]}"/>
+                </group>
+                <group string="Odoo layer data (Not implemented)"
+                       attrs="{'invisible': [('raster_type', '!=', 'odoo')]}"
+                       colspan="4">
+                    <field name="field_id"/>
+                </group>
+            </form>
+        </field>
+    </record>
 
-        <record id="geo_engine_view_rater_action" model="ir.actions.act_window">
-            <field name="name">Raster Layer</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">geoengine.raster.layer</field>
-            <field name="view_type">form</field>
-            <field name="view_id" ref="geo_raster_view_tree"/>
-        </record>
+    <record model="ir.ui.view" id="geo_raster_view_tree">
+        <field name="name">geoengine.raster.layer.tree</field>
+        <field name="model">geoengine.raster.layer</field>
+        <field name="arch" type="xml">
+            <tree string="Raster">
+                <field name="name" select="1"/>
+                <field name="raster_type" select="1"/>
+                <field name="sequence"/>
+                <field name="overlay" select="1"/>
+            </tree>
+        </field>
+    </record>
 
-        <menuitem name="Raster Layer Management" id="geoengine_raster_layer_menu"
-            parent="geoengine_base_view_menu" action="geo_engine_view_rater_action"
-            groups="group_geoengine_admin"/>
-    </data>
-</openerp>
+    <record id="geo_engine_view_rater_action" model="ir.actions.act_window">
+        <field name="name">Raster Layer</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">geoengine.raster.layer</field>
+        <field name="view_type">form</field>
+        <field name="view_id" ref="geo_raster_view_tree"/>
+    </record>
+
+    <menuitem name="Raster Layer Management" id="geoengine_raster_layer_menu"
+        parent="geoengine_base_view_menu" action="geo_engine_view_rater_action"
+        groups="group_geoengine_admin"/>
+
+</odoo>

--- a/base_geoengine/geo_view/geo_vector_layer.py
+++ b/base_geoengine/geo_view/geo_vector_layer.py
@@ -44,3 +44,5 @@ class GeoVectorLayer(models.Model):
         required=True)
     sequence = fields.Integer('layer priority lower on top', default=6)
     readonly = fields.Boolean('Layer is read only')
+    active_on_startup = fields.Boolean(
+        help="Layer will be shown on startup if checked.")

--- a/base_geoengine/geo_view/geo_vector_layer_view.xml
+++ b/base_geoengine/geo_view/geo_vector_layer_view.xml
@@ -11,6 +11,7 @@
                     <field name="view_id"/>
                     <field name="geo_field_id"/>
                     <field name="attribute_field_id" attrs="{'required': [('geo_repr', 'in', ['choropleth', 'proportion', 'colored'])]}"/>
+                    <field name="active_on_startup"/>
                     <field name="sequence"/>
                     <field name="readonly"/>
                 </group>
@@ -54,6 +55,7 @@
                 <field name="classification" select="1"/>
                 <field name="geo_field_id" select="1"/>
                 <field name="attribute_field_id" select="1"/>
+                <field name="active_on_startup"/>
                 <field name="sequence"/>
             </tree>
         </field>

--- a/base_geoengine/geo_view/geo_vector_layer_view.xml
+++ b/base_geoengine/geo_view/geo_vector_layer_view.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-        <record model="ir.ui.view" id="geo_vector_view_form">
-            <field name="name">geoengine.vector.layer.form</field>
-            <field name="model">geoengine.vector.layer</field>
-            <field name="arch" type="xml">
-                <form string="Vector">
-                    <group string="General" col="4">
-                        <field name="name" colspan="4"/>
-                        <field name="view_id"/>
-                        <field name="geo_field_id"/>
-                        <field name="attribute_field_id" attrs="{'required': [('geo_repr', 'in', ['choropleth', 'proportion', 'colored'])]}"/>
-                        <field name="sequence"/>
-                        <field name="readonly"/>
-                    </group>
-                    <group string="Representation" col="4" colspan="4">
-                        <field name="geo_repr"/>
-                    </group>
-                    <field name="symbol_ids" attrs="{'invisible': [('geo_repr', '!=', 'basic')]}">
-                        <tree editable="bottom">
-                          <field name="img" placeholder="module/static/img/icon.png"/>
-                          <field name="fieldname"/>
-                          <field name="value"/>
-                        </tree>
-                    </field>
-                    <group string="Classification" colspan="4"
-                        attrs="{'invisible': [('geo_repr', '=', 'basic')]}">
-                        <field name="classification"
-                            attrs="{'invisible': [('geo_repr', '=', 'basic')], 'required': [('geo_repr', 'in', ['choropleth', 'proportion', 'colored'])]}"
-                        />
-                    </group>
-                    <group string="Colors" col="4" colspan="4">
-                        <field name="begin_color"/>
-                        <group colspan="4" attrs="{'invisible': [('geo_repr', 'in', ['basic', 'proportion'])]}">
-                        <field name="end_color"
-                            attrs="{'invisible': [('classification', 'in', ['unique', False])], 'required': [('classification', 'in', ['interval', 'quantil'])]}"/>
-                        <field name="nb_class"
-                            attrs="{'invisible': [('classification', 'in', ['unique', False])], 'required': [('classification', 'in', ['interval', 'quantil'])]}"
-                        />
-                        </group>
-                    </group>
-                </form>
-            </field>
-        </record>
+<odoo>
 
-        <record model="ir.ui.view" id="geo_vector_view_tree">
-            <field name="name">geoengine.vector.layer.tree</field>
-            <field name="model">geoengine.vector.layer</field>
-            <field name="arch" type="xml">
-                <tree string="Vector">
-                    <field name="name" select="1"/>
-                    <field name="geo_repr" select="1"/>
-                    <field name="classification" select="1"/>
-                    <field name="geo_field_id" select="1"/>
-                    <field name="attribute_field_id" select="1"/>
+    <record model="ir.ui.view" id="geo_vector_view_form">
+        <field name="name">geoengine.vector.layer.form</field>
+        <field name="model">geoengine.vector.layer</field>
+        <field name="arch" type="xml">
+            <form string="Vector">
+                <group string="General" col="4">
+                    <field name="name" colspan="4"/>
+                    <field name="view_id"/>
+                    <field name="geo_field_id"/>
+                    <field name="attribute_field_id" attrs="{'required': [('geo_repr', 'in', ['choropleth', 'proportion', 'colored'])]}"/>
                     <field name="sequence"/>
-                </tree>
-            </field>
-        </record>
+                    <field name="readonly"/>
+                </group>
+                <group string="Representation" col="4" colspan="4">
+                    <field name="geo_repr"/>
+                </group>
+                <field name="symbol_ids" attrs="{'invisible': [('geo_repr', '!=', 'basic')]}">
+                    <tree editable="bottom">
+                      <field name="img" placeholder="module/static/img/icon.png"/>
+                      <field name="fieldname"/>
+                      <field name="value"/>
+                    </tree>
+                </field>
+                <group string="Classification" colspan="4"
+                    attrs="{'invisible': [('geo_repr', '=', 'basic')]}">
+                    <field name="classification"
+                        attrs="{'invisible': [('geo_repr', '=', 'basic')], 'required': [('geo_repr', 'in', ['choropleth', 'proportion', 'colored'])]}"
+                    />
+                </group>
+                <group string="Colors" col="4" colspan="4">
+                    <field name="begin_color"/>
+                    <group colspan="4" attrs="{'invisible': [('geo_repr', 'in', ['basic', 'proportion'])]}">
+                    <field name="end_color"
+                        attrs="{'invisible': [('classification', 'in', ['unique', False])], 'required': [('classification', 'in', ['interval', 'quantil'])]}"/>
+                    <field name="nb_class"
+                        attrs="{'invisible': [('classification', 'in', ['unique', False])], 'required': [('classification', 'in', ['interval', 'quantil'])]}"
+                    />
+                    </group>
+                </group>
+            </form>
+        </field>
+    </record>
 
-        <record id="geo_engine_view_raster_action" model="ir.actions.act_window">
-            <field name="name">Vector Layer</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">geoengine.vector.layer</field>
-            <field name="view_type">form</field>
-            <field name="view_id" ref="geo_vector_view_tree"/>
-        </record>
+    <record model="ir.ui.view" id="geo_vector_view_tree">
+        <field name="name">geoengine.vector.layer.tree</field>
+        <field name="model">geoengine.vector.layer</field>
+        <field name="arch" type="xml">
+            <tree string="Vector">
+                <field name="name" select="1"/>
+                <field name="geo_repr" select="1"/>
+                <field name="classification" select="1"/>
+                <field name="geo_field_id" select="1"/>
+                <field name="attribute_field_id" select="1"/>
+                <field name="sequence"/>
+            </tree>
+        </field>
+    </record>
 
-        <menuitem name="Vector Layer Management" id="geoengine_vector_layer_menu"
-            parent="geoengine_base_view_menu" action="geo_engine_view_raster_action"
-            groups="group_geoengine_admin"/>
-    </data>
-</openerp>
+    <record id="geo_engine_view_raster_action" model="ir.actions.act_window">
+        <field name="name">Vector Layer</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">geoengine.vector.layer</field>
+        <field name="view_type">form</field>
+        <field name="view_id" ref="geo_vector_view_tree"/>
+    </record>
+
+    <menuitem name="Vector Layer Management" id="geoengine_vector_layer_menu"
+        parent="geoengine_base_view_menu" action="geo_engine_view_raster_action"
+        groups="group_geoengine_admin"/>
+
+</odoo>

--- a/base_geoengine/geo_view/ir_view_view.xml
+++ b/base_geoengine/geo_view/ir_view_view.xml
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-        <record model="ir.ui.view" id="geoengine_view_form">
-            <field name="name">geoengine.view.form</field>
-            <field name="model">ir.ui.view</field>
-            <field name="inherit_id" ref="base.view_view_form"/>
-            <field name="type">form</field>
-            <field name="arch" type="xml">
-                <notebook position="inside">
-                    <page string="GeoEngine Data" col="4"
-                        attrs="{'invisible': [('type', '!=', 'geoengine')]}">
-                        <group>
-                            <field name="projection"/>
-                            <field name="restricted_extent" colspan="4"/>
-                            <field name="default_extent" colspan="4"/>
-                            <field name="default_zoom"/>
-                        </group>
-                        <separator string="Vector (Active layers)" colspan="4"/>
-                        <field name="vector_layer_ids" colspan="4" nolabel="1"/>
-                        <separator string="Raster (Background layers)" colspan="4"/>
-                        <field name="raster_layer_ids" colspan="4" nolabel="1"/>
-                    </page>
-                </notebook>
-            </field>
-        </record>
-        <menuitem name="Configuration" id="geoengine_base_view_menu"
-            parent="geoengine_base_menu"
-            groups="group_geoengine_admin" />
+<odoo>
 
-        <record id="geo_engine_view_action" model="ir.actions.act_window">
-            <field name="name">Views</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">ir.ui.view</field>
-            <field name="view_type">form</field>
-            <field name="view_id" ref="base.view_view_tree"/>
-            <field name="search_view_id" ref="base.action_view_search"/>
-            <field name="domain">[('type', '=', 'geoengine')]</field>
-        </record>
+    <record model="ir.ui.view" id="geoengine_view_form">
+        <field name="name">geoengine.view.form</field>
+        <field name="model">ir.ui.view</field>
+        <field name="inherit_id" ref="base.view_view_form"/>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="GeoEngine Data" col="4"
+                    attrs="{'invisible': [('type', '!=', 'geoengine')]}">
+                    <group>
+                        <field name="projection"/>
+                        <field name="restricted_extent" colspan="4"/>
+                        <field name="default_extent" colspan="4"/>
+                        <field name="default_zoom"/>
+                    </group>
+                    <separator string="Vector (Active layers)" colspan="4"/>
+                    <field name="vector_layer_ids" colspan="4" nolabel="1"/>
+                    <separator string="Raster (Background layers)" colspan="4"/>
+                    <field name="raster_layer_ids" colspan="4" nolabel="1"/>
+                </page>
+            </notebook>
+        </field>
+    </record>
+    <menuitem name="Configuration" id="geoengine_base_view_menu"
+        parent="geoengine_base_menu"
+        groups="group_geoengine_admin" />
 
-        <menuitem name="View Management" id="geoengine_view_menu"
-            parent="geoengine_base_view_menu" action="geo_engine_view_action"
-            groups="group_geoengine_admin"/>
-    </data>
-</openerp>
+    <record id="geo_engine_view_action" model="ir.actions.act_window">
+        <field name="name">Views</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">ir.ui.view</field>
+        <field name="view_type">form</field>
+        <field name="view_id" ref="base.view_view_tree"/>
+        <field name="search_view_id" ref="base.action_view_search"/>
+        <field name="domain">[('type', '=', 'geoengine')]</field>
+    </record>
+
+    <menuitem name="View Management" id="geoengine_view_menu"
+        parent="geoengine_base_view_menu" action="geo_engine_view_action"
+        groups="group_geoengine_admin"/>
+
+</odoo>

--- a/base_geoengine/security/data.xml
+++ b/base_geoengine/security/data.xml
@@ -2,11 +2,11 @@
 <odoo>
 
     <record id="group_geoengine_user" model="res.groups">
-        <field name="name">Geoengine user</field>
+        <field name="name">Geoengine User</field>
     </record>
 
     <record id="group_geoengine_admin" model="res.groups">
-        <field name="name">Geoengine admin</field>
+        <field name="name">Geoengine Admin</field>
         <field name="implied_ids" eval="[(4, ref('group_geoengine_user')),]"/>
         <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>

--- a/base_geoengine/security/data.xml
+++ b/base_geoengine/security/data.xml
@@ -1,15 +1,14 @@
-<openerp>
-    <data>
-    
-        <record id="group_geoengine_user" model="res.groups">
-            <field name="name">Geoengine user</field>
-        </record>
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
 
-        <record id="group_geoengine_admin" model="res.groups">
-            <field name="name">Geoengine admin</field>
-            <field name="implied_ids" eval="[(4, ref('group_geoengine_user')),]"/>
-            <field name="users" eval="[(4, ref('base.user_root'))]"/>
-        </record>
+    <record id="group_geoengine_user" model="res.groups">
+        <field name="name">Geoengine user</field>
+    </record>
 
-    </data>
-</openerp>
+    <record id="group_geoengine_admin" model="res.groups">
+        <field name="name">Geoengine admin</field>
+        <field name="implied_ids" eval="[(4, ref('group_geoengine_user')),]"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    </record>
+
+</odoo>

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -123,3 +123,58 @@ div.ol-clear {
     width: 100%;
     height: 500px;
 }
+
+.ol-popup {
+    position: absolute;
+    background-color: white;
+    -webkit-filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
+    filter: drop-shadow(0 1px 4px rgba(0, 0, 0, 0.2));
+    padding: 15px;
+    border-radius: 10px;
+    border: 1px solid #cccccc;
+    bottom: 12px;
+    left: -50px;
+    min-width: 280px;
+}
+
+.ol-popup:after, .ol-popup:before {
+    top: 100%;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+}
+
+.ol-popup:after {
+    border-top-color: white;
+    border-width: 10px;
+    left: 48px;
+    margin-left: -10px;
+}
+
+.ol-popup:before {
+    border-top-color: #cccccc;
+    border-width: 11px;
+    left: 48px;
+    margin-left: -11px;
+}
+
+.ol-popup-edit {
+    text-decoration: none;
+    position: absolute;
+    top: 5px;
+    right: 25px;
+}
+
+.ol-popup-closer {
+    text-decoration: none;
+    position: absolute;
+    top: 2px;
+    right: 8px;
+}
+
+.ol-popup-closer:after {
+    content: "✖";
+}

--- a/base_geoengine/static/src/js/views/geoengine_record.js
+++ b/base_geoengine/static/src/js/views/geoengine_record.js
@@ -1,0 +1,81 @@
+odoo.define('base_geoengine.Record', function (require) {
+    "use strict";
+
+    var core = require('web.core');
+    var data = require('web.data');
+    var formats = require('web.formats');
+    var framework = require('web.framework');
+    var session = require('web.session');
+    var time = require('web.time');
+    var utils = require('web.utils');
+    var Widget = require('web.Widget');
+
+    var fields_registry = require('base_geoengine.template_widgets').registry;
+
+    var GeoengineRecord = Widget.extend({
+        template: 'Geoengine.Record',
+
+        init: function (parent, record, options) {
+            var self = this;
+            self._super(parent);
+            self.fields = options.fields;
+            self.qweb = options.qweb;
+            self.record = record;
+            self.id = record.id;
+            self.sub_widgets = [];
+            self.init_content();
+        },
+
+        init_content: function() {
+            var self = this;
+            self.record = self.transform_record(self.record);
+            self.render_content();
+        },
+
+        transform_record: function(record) {
+            var self = this;
+            var new_record = {};
+            _.each(_.extend(_.object(_.keys(this.fields), []), record), function(value, name) {
+                var r = _.clone(self.fields[name] || {});
+                r.raw_value = value;
+                r.value = formats.format_value(value, r);
+                new_record[name] = r;
+            });
+            return new_record;
+        },
+
+        render_content: function() {
+            var self = this;
+            var qweb_context = {
+                record: self.record,
+                widget: self,
+                user_context: session.user_context,
+                formats: formats,
+            };
+            self.content = self.qweb.render('layer-box', qweb_context);
+        },
+
+        start: function() {
+            var self = this;
+            self.add_widgets();
+        },
+
+        add_widgets: function() {
+            var self = this;
+            self.$("field").each(function() {
+                var $field = $(this);
+                var field = self.record[$field.attr("name")];
+                var type = $field.attr("widget") || field.type;
+                var FieldWidget = fields_registry.get(type);
+                if (FieldWidget !== undefined) {
+                    var widget = new FieldWidget(self, field, $field);
+                    widget.replace($field);
+                    self.sub_widgets.push(widget);
+                }
+            });
+        },
+
+    });
+
+    return GeoengineRecord;
+});

--- a/base_geoengine/static/src/js/views/geoengine_template_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_template_widgets.js
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------
+ * Odoo base_geoengine
+ * Contributor N. Bessi Copyright Camptocamp SA
+ * Author Benjamin Willig 2017 Acsone SA/NV
+ *---------------------------------------------------------
+*/
+
+odoo.define('base_geoengine.template_widgets', function (require) {
+    "use strict";
+
+    var core = require('web.core');
+    var formats = require('web.formats');
+    var pyeval = require('web.pyeval');
+    var Registry = require('web.Registry');
+    var session = require('web.session');
+    var Widget = require('web.Widget');
+
+    /**
+     * Interface to be implemented by geonengine fields.
+     *
+     */
+    var FieldInterface = {
+        /**
+            Constructor.
+            - parent: The widget's parent.
+            - field: A dictionary giving details about the field, including the current field's value in the
+                raw_value field.
+            - $node: The field <field> tag as it appears in the view, encapsulated in a jQuery object.
+        */
+        init: function(parent, field, $node) {},
+    };
+
+    /**
+     * Abstract class for classes implementing FieldInterface.
+     *
+     * Properties:
+     *     - value: useful property to hold the value of the field. By default, the constructor
+     *     sets value property.
+     *
+     */
+    var AbstractField = Widget.extend(FieldInterface, {
+        /**
+            Constructor that saves the field and $node parameters and sets the "value" property.
+        */
+        init: function(parent, field, $node) {
+            this._super(parent, field, $node);
+            this.field = field;
+            this.$node = $node;
+            this.options = pyeval.py_eval(this.$node.attr("options") || '{}');
+            this.format_descriptor = _.extend({}, this.field, {'widget': this.$node.attr('widget')});
+            this.set("value", field.raw_value);
+        },
+        renderElement: function() {
+            this.$el.text(formats.format_value(this.field.raw_value, this.format_descriptor));
+        }
+    });
+
+    var FieldChar = AbstractField.extend({
+        tagName: 'span',
+    });
+
+    var FieldMany2one = AbstractField.extend({
+        tagName: 'span',
+    });
+
+    var FieldFloat = AbstractField.extend({
+        tagName: 'span',
+    });
+
+    var FieldFloatTime = AbstractField.extend({
+        tagName: 'span',
+    });
+
+    var FieldDate = AbstractField.extend({
+        tagName: 'span',
+    });
+
+    var FieldDatetime = AbstractField.extend({
+        tagName: 'span',
+    });
+
+    var fields_registry = new Registry();
+    fields_registry
+        .add('char', FieldChar)
+        .add('many2one', FieldMany2one)
+        .add('float', FieldFloat)
+        .add('float_time', FieldFloat)
+        .add('date', FieldDate)
+        .add('datetime', FieldDatetime)
+    ;
+
+    return {
+        AbstractField: AbstractField,
+        registry: fields_registry,
+    };
+
+});

--- a/base_geoengine/static/src/js/views/geoengine_template_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_template_widgets.js
@@ -1,6 +1,5 @@
 /*---------------------------------------------------------
  * Odoo base_geoengine
- * Contributor N. Bessi Copyright Camptocamp SA
  * Author Benjamin Willig 2017 Acsone SA/NV
  *---------------------------------------------------------
 */
@@ -8,11 +7,9 @@
 odoo.define('base_geoengine.template_widgets', function (require) {
     "use strict";
 
-    var core = require('web.core');
     var formats = require('web.formats');
     var pyeval = require('web.pyeval');
     var Registry = require('web.Registry');
-    var session = require('web.session');
     var Widget = require('web.Widget');
 
     /**

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -230,6 +230,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         var lv = new ol.layer.Vector({
             source: vectorSource,
             title: cfg.name,
+            active_on_startup: cfg.active_on_startup,
             // opacity: 0.8, //TODO cenfiguarble opacity to be applied on
             style: styleInfo.style,
         });
@@ -447,8 +448,8 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         });
 
         _.each(vectorLayers, function(vlayer) {
-            // keep only one vector layer active at startup
-            if (vlayer != vectorLayers[0]) {
+            // First vector always visible on startup
+            if (vlayer !== vectorLayers[0] && !vlayer.values_.active_on_startup) {
                 vlayer.setVisible(false);
             }
         });

--- a/base_geoengine/static/src/xml/geoengine.xml
+++ b/base_geoengine/static/src/xml/geoengine.xml
@@ -1,98 +1,116 @@
-<template>
-  <div t-name="GeoengineView" t-att-id="elem_id" class="container-fluid o_geoengine_container" style="height:100%;position:relative;">
-    <br />
-    <div id="olmap" class="olmap">
-      <div id="map_infobox" class="map_overlay">
-        <div id="map_info_open">
-          <span class="fa fa-edit"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <div t-name="GeoengineView" t-att-id="elem_id"
+         class="container-fluid o_geoengine_container"
+         style="height:100%;position:relative;">
+        <br/>
+        <div id="olmap" class="olmap">
+            <div id="map_infobox" class="map_overlay">
+
+                <div id="map_info_open">
+                    <span class="fa fa-edit"/>
+                </div>
+                <div id="map_info_filter_selection">
+                    <span class="fa fa-filter">Filter selection</span>
+                </div>
+                <div id="map_info"/>
+            </div>
+
+            <div class="layer-popup ol-popup">
+                <a href="javascript: void(0)" class="ol-popup-edit fa fa-edit"/>
+                <a href="javascript: void(0)" class="popup-closer ol-popup-closer"/>
+                <div class="popup-content">
+                    <div/>
+                </div>
+            </div>
+
+            <div id="map_legend" class="ol-control"/>
         </div>
-        <div id="map_info_filter_selection">
-          <span class="fa fa-filter"> Filter selection</span>
+    </div>
+
+    <t t-name="Geoengine.Record">
+        <div>
+            <t t-raw="widget.content"/>
         </div>
-        <div id="map_info"/>
-      </div>
-      <div id="map_legend" class="ol-control"/>
-    </div>
-  </div>
+    </t>
 
-  <t t-name="FieldGeoPointXY">
-    <table cellpadding="0" cellspacing="0" border="0" width="100%">
-    <tr>
-      <td align="center" valign="middle">
-        X:
-      </td>
-      <td width="47%" valign="top">
-        <t t-call="FieldChar"/>
-      </td>
-      <td align="center" valign="middle">
-        Y:
-      </td>
-      <td width="47%" valign="top">
-        <t t-call="FieldChar"/>
-      </td>
-    </tr>
-    </table>
-  </t>
+    <t t-name="FieldGeoPointXY">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+                <td align="center" valign="middle">
+                    X:
+                </td>
+                <td width="47%" valign="top">
+                    <t t-call="FieldChar"/>
+                </td>
+                <td align="center" valign="middle">
+                    Y:
+                </td>
+                <td width="47%" valign="top">
+                    <t t-call="FieldChar"/>
+                </td>
+            </tr>
+        </table>
+    </t>
 
-  <t t-name="FieldGeoPointXY.readonly">
-    <div
-        t-att-id="widget.name"
-        t-attf-class="field_#{widget.widget} #{_(['geo_point_xy']).contains(widget.widget) ? 'oe-number' : ''}">
-    </div>
-  </t>
+    <t t-name="FieldGeoPointXY.readonly">
+        <div t-att-id="widget.name"
+             t-attf-class="field_#{widget.widget} #{_(['geo_point_xy']).contains(widget.widget) ? 'oe-number' : ''}">
+        </div>
+    </t>
 
-  <t t-name="FieldGeoRect">
-    <table cellpadding="0" cellspacing="0" border="0" width="100%">
-    <tr>
-      <td colspan="4" valign="middle">
-        Bottom-Left
-      </td>
-    </tr>
-    <tr>
-      <td align="center" valign="middle">
-        X:
-      </td>
-      <td width="47%" valign="top">
-        <t t-call="FieldChar"/>
-      </td>
-      <td align="center" valign="middle">
-        Y:
-      </td>
-      <td width="47%" valign="top">
-        <t t-call="FieldChar"/>
-      </td>
-    </tr>
-    <tr>
-      <td colspan="4" valign="middle">
-        Up-Right
-      </td>
-    </tr>
-    <tr>
-      <td align="center" valign="middle">
-        X:
-      </td>
-      <td width="47%" valign="top">
-        <t t-call="FieldChar"/>
-      </td>
-      <td align="center" valign="middle">
-        Y:
-      </td>
-      <td width="47%" valign="top">
-        <t t-call="FieldChar"/>
-      </td>
-    </tr>
-    </table>
-  </t>
-  <t t-name="FieldGeoRect.readonly">
-    <div
-        t-att-id="widget.name"
-        t-attf-class="field_#{widget.widget} #{_(['geo_point_xy']).contains(widget.widget) ? 'oe-number' : ''}">
-    </div>
-  </t>
+    <t t-name="FieldGeoRect">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+                <td colspan="4" valign="middle">
+                    Bottom-Left
+                </td>
+            </tr>
+            <tr>
+                <td align="center" valign="middle">
+                    X:
+                </td>
+                <td width="47%" valign="top">
+                    <t t-call="FieldChar"/>
+                </td>
+                <td align="center" valign="middle">
+                    Y:
+                </td>
+                <td width="47%" valign="top">
+                    <t t-call="FieldChar"/>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="4" valign="middle">
+                    Up-Right
+                </td>
+            </tr>
+            <tr>
+                <td align="center" valign="middle">
+                    X:
+                </td>
+                <td width="47%" valign="top">
+                    <t t-call="FieldChar"/>
+                </td>
+                <td align="center" valign="middle">
+                    Y:
+                </td>
+                <td width="47%" valign="top">
+                    <t t-call="FieldChar"/>
+                </td>
+            </tr>
+        </table>
+    </t>
+    <t t-name="FieldGeoRect.readonly">
+        <div t-att-id="widget.name"
+             t-attf-class="field_#{widget.widget} #{_(['geo_point_xy']).contains(widget.widget) ? 'oe-number' : ''}">
+        </div>
+    </t>
 
+    <t t-name="FieldGeoEngineEditMap">
+        <div t-att-id="widget.name" t-attf-class="field_#{widget.widget}"
+             border="1"/>
+    </t>
 
-  <t t-name="FieldGeoEngineEditMap">
-    <div t-att-id="widget.name" t-attf-class="field_#{widget.widget}" border="1"/>
-  </t>
-
-</template>
+</templates>

--- a/base_geoengine/tests/data.py
+++ b/base_geoengine/tests/data.py
@@ -119,7 +119,7 @@ FORM_VIEW = {
             "geo_type": {
                 "dim": 2,
                 "srid": 900913,
-                "type": "MULTIPOLYGON"
+                "type": "geo_multi_polygon"
             },
             "required": False,
             "searchable": True,

--- a/base_geoengine/tests/test_geoengine.py
+++ b/base_geoengine/tests/test_geoengine.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Laurent Mignon Acsone SA/NV (http://www.acsone.eu)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import mock
-import simplejson
 from cStringIO import StringIO
 import logging
+import geojson
+import mock
+import simplejson
+
 from shapely.wkt import loads as wktloads
 from shapely.geometry import Polygon, MultiPolygon
 from shapely.geometry.linestring import LineString
 from shapely.geometry.point import Point
-import geojson
 
 import odoo.tests.common as common
 from odoo import fields
@@ -90,11 +91,11 @@ class TestGeoengine(common.TransactionCase):
                 </geoengine> """
         })
 
-    def _init_test_model(cls, model_cls):
-        registry = cls.env.registry
-        cr = cls.env.cr
+    def _init_test_model(self, model_cls):
+        registry = self.env.registry
+        cr = self.env.cr
         model_cls._build_model(registry, cr)
-        model = cls.env[model_cls._name].with_context(todo=[])
+        model = self.env[model_cls._name].with_context(todo=[])
         model._prepare_setup()
         model._setup_base(partial=False)
         model._setup_fields(partial=False)
@@ -189,10 +190,7 @@ class TestGeoengine(common.TransactionCase):
         ids = self.test_model.geo_search(
             domain=[],
             geo_domain=[
-                ('the_geom',
-                 'geo_contains',
-                 'POINT(1 1)'
-                 )
+                ('the_geom', 'geo_contains', 'POINT(1 1)')
             ])
         self.assertListEqual([self.dummy_id], ids)
 

--- a/base_geoengine/views/base_geoengine_view.xml
+++ b/base_geoengine/views/base_geoengine_view.xml
@@ -1,24 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<template id="assets_backend" inherit_id="web.assets_backend">
-  <xpath expr="." position="inside">
-    <script type="text/javascript" src="/base_geoengine/static/src/js/lib/ol-3.18.2/ol-debug.js"></script>
-    <script type="text/javascript" src="/base_geoengine/static/src/js/lib/ol3-layerswitcher.js"></script>
 
-    <script type="text/javascript" src="/base_geoengine/static/src/js/views/geoengine_common.js"></script>
-    <script type="text/javascript" src="/base_geoengine/static/src/js/views/geoengine_view.js"></script>
-    <script type="text/javascript" src="/base_geoengine/static/src/js/views/geoengine_widgets.js"></script>
-    <script type="text/javascript" src="/base_geoengine/static/src/js/lib/chromajs-0.8.0/chroma.js"/>
-    <script type="text/javascript" src="/base_geoengine/static/src/js/lib/geostats-1.4.0/geostats.js"/>
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/lib/ol-3.18.2/ol-debug.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/lib/ol3-layerswitcher.js"/>
 
-    <link rel="stylesheet" href="/base_geoengine/static/src/js/lib/ol-3.18.2/ol.css"/>
-    <link rel="stylesheet" href="/base_geoengine/static/src/js/lib/geostats-1.4.0/geostats.css"/>
-    <link rel="stylesheet" href="/base_geoengine/static/src/css/style.css"/>
-    <link rel="stylesheet" href="/base_geoengine/static/src/js/lib/ol3-layerswitcher.css"/>
-  </xpath>
-</template>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/views/geoengine_common.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/views/geoengine_record.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/views/geoengine_template_widgets.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/views/geoengine_view.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/views/geoengine_widgets.js"/>
 
-<menuitem name="GeoEngine Backend" id="geoengine_base_menu"
-          web_icon="base_geoengine,images/map.png" groups="group_geoengine_admin"
-          web_icon_hover="base_geoengine,images/map-hover.png"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/lib/chromajs-0.8.0/chroma.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/lib/geostats-1.4.0/geostats.js"/>
+
+            <link rel="stylesheet"
+                  href="/base_geoengine/static/src/js/lib/ol-3.18.2/ol.css"/>
+            <link rel="stylesheet"
+                  href="/base_geoengine/static/src/js/lib/geostats-1.4.0/geostats.css"/>
+            <link rel="stylesheet"
+                  href="/base_geoengine/static/src/css/style.css"/>
+            <link rel="stylesheet"
+                  href="/base_geoengine/static/src/js/lib/ol3-layerswitcher.css"/>
+        </xpath>
+    </template>
+
+    <menuitem name="GeoEngine Backend" id="geoengine_base_menu"
+              web_icon="base_geoengine,images/map.png"
+              groups="group_geoengine_admin"
+              web_icon_hover="base_geoengine,images/map-hover.png"/>
+
 </odoo>

--- a/base_geoengine_demo/__manifest__.py
+++ b/base_geoengine_demo/__manifest__.py
@@ -17,6 +17,11 @@
      'data/npa_geom.xml',
      'security/ir.model.access.csv'
  ],
+ 'external_dependencies': {
+     'python': [
+         'geojson',
+     ],
+ },
  'installable': True,
  'application': True,
  }


### PR DESCRIPTION
* Implemented convert_to_cache and convert_to_record methods. (Store BaseGeometry hex code in cache and convert it back to BaseGeometry instance when reading from record)
* Added test in convert_to_read method to prevent errors when assigning a BaseGeometry instance to a Geo field.
* New method to create a GeoLine from two points
* Create Geometry column when column is computed but stored
* Fixed tests
* Corrected some pylint issues
* Allow to define which layers will be active on startup
* Allow to show a configurable popup when selecting an item.  Geonengine templates works like kanban box templates.
* Added a hook to allow to set a different style when selecting/hovering a layer
* Allow to change the circle radius with inheritance