### PR TITLE
[9.0, FIX] not geoengine views are no longer editable in UI

### DIFF
--- a/base_geoengine/geo_view/ir_view.py
+++ b/base_geoengine/geo_view/ir_view.py
@@ -28,7 +28,7 @@ class IrUIView(models.Model):
         'geoengine.raster.layer', 'view_id', 'Raster layers', required=False)
 
     vector_layer_ids = fields.One2many(
-        'geoengine.vector.layer', 'view_id', 'Vector layers', required=True)
+        'geoengine.vector.layer', 'view_id', 'Vector layers')
 
     projection = fields.Char(default="EPSG:900913", required=True)
     default_extent = fields.Char(


### PR DESCRIPTION
The `required=True`on the field `vector_layer_ids` is too intrusive. It forbids to update views with the user interface. Note: from V10, this property on a o2m seems to be no longer checked by js.