### PR TITLE
[10, Add] Allow to set opacity on layers

### DIFF
--- a/base_geoengine/geo_view/geo_vector_layer.py
+++ b/base_geoengine/geo_view/geo_vector_layer.py
@@ -46,3 +46,4 @@ class GeoVectorLayer(models.Model):
     readonly = fields.Boolean('Layer is read only')
     active_on_startup = fields.Boolean(
         help="Layer will be shown on startup if checked.")
+    layer_opacity = fields.Float('Layer Opacity')

--- a/base_geoengine/geo_view/geo_vector_layer_view.xml
+++ b/base_geoengine/geo_view/geo_vector_layer_view.xml
@@ -14,6 +14,7 @@
                     <field name="active_on_startup"/>
                     <field name="sequence"/>
                     <field name="readonly"/>
+                    <field name="layer_opacity"/>
                 </group>
                 <group string="Representation" col="4" colspan="4">
                     <field name="geo_repr"/>

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -270,6 +270,9 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             }
         });
         this.vectorSources.push(vectorSource);
+        if (cfg.layer_opacity){
+            lv.setOpacity(cfg.layer_opacity);
+        }
         return lv;
     },
 

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -259,7 +259,6 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
             source: vectorSource,
             title: cfg.name,
             active_on_startup: cfg.active_on_startup,
-            // opacity: 0.8, //TODO cenfiguarble opacity to be applied on
             style: styleInfo.style,
         });
         lv.on('change:visible', function(e){


### PR DESCRIPTION
# Description
Allow to set opacity on layers.
Users now have choice to view some layers together or separately, whatever they choose.


Without opacity
![screenshot from 2018-06-02 23 01 24](https://user-images.githubusercontent.com/10609055/40879255-f01c188e-66ba-11e8-9626-05f254b30b86.png)


With opacity
![screenshot from 2018-06-02 22 59 27](https://user-images.githubusercontent.com/10609055/40879270-06ddadee-66bb-11e8-8a73-d5aecae74a52.png)


# Configuration required
Set opacity on layers. Like
![colored range zip eq interval odoo 1](https://user-images.githubusercontent.com/10609055/40879285-224e524a-66bb-11e8-9ca5-628012aa5eef.png)

Pleasure to help, changes are welcome.