### PR TITLE
[FIX] typo in base_geoengine javascript.

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -436,7 +436,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 ];
                 return {
                      style : function(feature, resolution) {
-                          var label_text = feature.values_.attributes.label.;
+                          var label_text = feature.values_.attributes.label;
                           if(label_text === false){
                             label_text = '';
                           }


### PR DESCRIPTION
There is a typo in the javascript of base_geoengine module which is causing Odoo to display a blank page in the backend. This fixes it.