### PR TITLE
[ADD] 8.0 base_geoengine: backport base_zoom from 9.0

### DIFF
--- a/base_geoengine/__init__.py
+++ b/base_geoengine/__init__.py
@@ -19,13 +19,13 @@
 #
 ##############################################################################
 """The GeoEngine module"""
+from . import geo_point
 from . import geo_model
 from . import geo_operators
 from . import geo_view
 from . import geo_helper
 from . import geo_ir
 from . import geo_field
-from . import geo_point
 from . import geo_multipoint
 from . import geo_line
 from . import geo_multiline

--- a/base_geoengine/geo_field.py
+++ b/base_geoengine/geo_field.py
@@ -241,6 +241,7 @@ class GeoFunction(fields.function):
     # shell class
     pass
 
+
 GeoFunction.postprocess = postprocess
 fields.geo_function = GeoFunction
 
@@ -248,5 +249,7 @@ fields.geo_function = GeoFunction
 class GeoRelated(fields.related):
     # shell class
     pass
+
+
 GeoRelated.postprocess = postprocess
 fields.geo_related = GeoRelated

--- a/base_geoengine/geo_line.py
+++ b/base_geoengine/geo_line.py
@@ -32,4 +32,5 @@ class GeoLine(geo_field.Geom):
             string, dim=dim, srid=srid, gist_index=gist_index,
             **args)
 
+
 fields.geo_line = GeoLine

--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -132,6 +132,7 @@ class GeoModel(models.BaseModel):
             default_extent = (view.default_extent or DEFAULT_EXTENT).split(',')
             res['geoengine_layers']['default_extent'] = [
                 float(x) for x in default_extent]
+            res['geoengine_layers']['default_zoom'] = view.default_zoom
             # TODO find why context in read does not work with webclient
             for layer in view.raster_layer_ids:
                 layer_dict = raster_obj.read(cursor, uid, layer.id)
@@ -176,6 +177,7 @@ class GeoModel(models.BaseModel):
         res['geo_type'] = field.geo_type
         res['srid'] = field.srid
         res['default_extent'] = view.default_extent
+        res['default_zoom'] = view.default_zoom
         return res
 
     def geo_search(self, cursor, uid, domain=None, geo_domain=None, offset=0,

--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -129,9 +129,11 @@ class GeoModel(models.BaseModel):
             res['geoengine_layers'] = {}
             res['geoengine_layers']['backgrounds'] = []
             res['geoengine_layers']['actives'] = []
-            default_extent = (view.default_extent or DEFAULT_EXTENT).split(',')
-            res['geoengine_layers']['default_extent'] = [
-                float(x) for x in default_extent]
+            res['geoengine_layers']['projection'] = view.projection
+            restricted_extent = view.restricted_extent
+            res['geoengine_layers']['restricted_extent'] = restricted_extent
+            default_extent = view.default_extent or DEFAULT_EXTENT
+            res['geoengine_layers']['default_extent'] = default_extent
             res['geoengine_layers']['default_zoom'] = view.default_zoom
             # TODO find why context in read does not work with webclient
             for layer in view.raster_layer_ids:
@@ -176,6 +178,8 @@ class GeoModel(models.BaseModel):
             cursor, uid, raster_id[0], context=context)
         res['geo_type'] = field.geo_type
         res['srid'] = field.srid
+        res['projection'] = view.projection
+        res['restricted_extent'] = view.restricted_extent
         res['default_extent'] = view.default_extent
         res['default_zoom'] = view.default_zoom
         return res

--- a/base_geoengine/geo_multiline.py
+++ b/base_geoengine/geo_multiline.py
@@ -32,4 +32,5 @@ class GeoMultiLine(geo_field.Geom):
             string, dim=dim, srid=srid,
             gist_index=gist_index, **args)
 
+
 fields.geo_multi_line = GeoMultiLine

--- a/base_geoengine/geo_multipoint.py
+++ b/base_geoengine/geo_multipoint.py
@@ -32,4 +32,5 @@ class GeoMultiPoint(geo_field.Geom):
             string, dim=dim, srid=srid, gist_index=gist_index,
             **args)
 
+
 fields.geo_multi_point = GeoMultiPoint

--- a/base_geoengine/geo_multipolygon.py
+++ b/base_geoengine/geo_multipolygon.py
@@ -32,4 +32,5 @@ class GeoMultiPolygon(geo_field.Geom):
             string, dim=dim, srid=srid, gist_index=gist_index,
             **args)
 
+
 fields.geo_multi_polygon = GeoMultiPolygon

--- a/base_geoengine/geo_point.py
+++ b/base_geoengine/geo_point.py
@@ -32,4 +32,5 @@ class GeoPoint(geo_field.Geom):
         super(GeoPoint, self).__init__(
             string, dim=dim, srid=srid, gist_index=gist_index, **args)
 
+
 fields.geo_point = GeoPoint

--- a/base_geoengine/geo_polygon.py
+++ b/base_geoengine/geo_polygon.py
@@ -32,4 +32,5 @@ class GeoPolygon(geo_field.Geom):
             string, dim=dim, srid=srid, gist_index=gist_index,
             **args)
 
+
 fields.geo_polygon = GeoPolygon

--- a/base_geoengine/geo_view/ir_view.py
+++ b/base_geoengine/geo_view/ir_view.py
@@ -46,10 +46,21 @@ class IrUIView(models.Model):
     vector_layer_ids = fields.One2many(
         'geoengine.vector.layer', 'view_id', 'Vector layers', required=True)
 
+    projection = fields.Char(
+        string="Projection",
+        default="EPSG:900913",
+        required=True,
+    )
     default_extent = fields.Char(
-        'Default map extent in 900913', size=128,
+        'Default map extent',
+        size=128,
         default='-123164.85222423, 5574694.9538936, 1578017.6490538,'
-        ' 6186191.1800898')
+        ' 6186191.1800898',
+    )
     default_zoom = fields.Integer(
         string="Default map zoom",
+    )
+    restricted_extent = fields.Char(
+        string="Restricted map extent",
+        size=128,
     )

--- a/base_geoengine/geo_view/ir_view.py
+++ b/base_geoengine/geo_view/ir_view.py
@@ -50,3 +50,6 @@ class IrUIView(models.Model):
         'Default map extent in 900913', size=128,
         default='-123164.85222423, 5574694.9538936, 1578017.6490538,'
         ' 6186191.1800898')
+    default_zoom = fields.Integer(
+        string="Default map zoom",
+    )

--- a/base_geoengine/geo_view/ir_view_view.xml
+++ b/base_geoengine/geo_view/ir_view_view.xml
@@ -12,6 +12,8 @@
                         attrs="{'invisible': [('type', '!=', 'geoengine')]}">
                         <group name="geo_data">
                             <field name="default_zoom"/>
+                            <field name="projection"/>
+                            <field name="restricted_extent" colspan="4"/>
                             <field name="default_extent" colspan="4"/>
                         </group>
                         <separator string="Vector (Active layers)" colspan="4"/>

--- a/base_geoengine/geo_view/ir_view_view.xml
+++ b/base_geoengine/geo_view/ir_view_view.xml
@@ -10,7 +10,10 @@
                 <notebook position="inside">
                     <page string="GeoEngine Data" col="4"
                         attrs="{'invisible': [('type', '!=', 'geoengine')]}">
-                        <field name="default_extent" colspan="4"/>
+                        <group name="geo_data">
+                            <field name="default_zoom"/>
+                            <field name="default_extent" colspan="4"/>
+                        </group>
                         <separator string="Vector (Active layers)" colspan="4"/>
                         <field name="vector_layer_ids" colspan="4" nolabel="1"/>
                         <separator string="Raster (Background layers)" colspan="4"/>

--- a/base_geoengine/static/src/css/style.css
+++ b/base_geoengine/static/src/css/style.css
@@ -9,7 +9,7 @@ div.olMap {
 .olMap svg{
     width: initial;
     height: initial;
-    
+
 }
 
 div.olMapViewport {
@@ -189,12 +189,12 @@ a.olControlZoomOut {
 }
 .map_overlay {
     position: absolute;
-        display: none;
-        background: white;
+    display: none;
+    background: white;
     opacity: 0.9;
-        border: 2px solid black;
-        z-index: 3000;
-        padding: 5px 0;
+    border: 2px solid black;
+    z-index: 3000;
+    padding: 5px 0;
 }
 #map_infobox {
         bottom: 10px;
@@ -209,6 +209,12 @@ a.olControlZoomOut {
         overflow-y: auto;
         padding: 10px;
         height: 130px;
+}
+#map_info_open {
+    background-color: #337ab7;
+    vertical-align: middle;
+    text-align: center;
+    color: white;
 }
 #map_info_filter_selection {
         position: absolute;

--- a/base_geoengine/static/src/js/geoengine_view.js
+++ b/base_geoengine/static/src/js/geoengine_view.js
@@ -263,6 +263,9 @@ openerp.base_geoengine = function(openerp) {
                         var selectedFeatures = this.selectedFeatures[0].layer.selectedFeatures;
                         if (selectedFeatures.length == 1) {
                             $("#map_info").html(formatFeatureHTML(event.feature.attributes, self.fields_view.fields));
+                            $('#map_infobox').off().click(function() {
+                                self.open_record(event.feature);
+                            });
                             $("#map_info_filter_selection").hide();
                         } else {
                             $("#map_info").html(formatFeatureListHTML(selectedFeatures));
@@ -360,6 +363,15 @@ openerp.base_geoengine = function(openerp) {
                 geostat.applyClassification();
             }
             return vl;
+        },
+
+        open_record: function (feature, options) {
+            var oid = feature.attributes.id;
+            if (this.dataset.select_id(oid)) {
+                this.do_switch_view('form', null, options);
+            } else {
+                this.do_warn("Geoengine: could not find id#" + oid);
+            }
         },
 
         getUniqueValuesStyleMap: function(cfg, features) {

--- a/base_geoengine/static/src/js/geoengine_view.js
+++ b/base_geoengine/static/src/js/geoengine_view.js
@@ -744,6 +744,7 @@ openerp.base_geoengine = function(openerp) {
                 self.layers = self.create_edit_layers(self, result);
                 self.geo_type = result.geo_type;
                 self.default_extent = result.default_extent;
+                self.default_zoom = result.default_zoom;
                 self.srid = result.srid;
                 if (self.$el.is(':visible')){
                     self.render_map();
@@ -751,18 +752,25 @@ openerp.base_geoengine = function(openerp) {
             });
         },
 
-        set_value: function(value) {
+        set_value: function(value, zoom = true) {
             this._super.apply(this, arguments);
             this.value = value;
             if (this.map) {
                 var vl = this.map.getLayersByName(this.name)[0];
                 vl.destroyFeatures();
+                var extent = this.default_extend;
                 if (this.value) {
                     var features = this.format.read(this.value);
-                    vl.addFeatures(features, {silent: true});
-                    this.map.zoomToExtent(vl.getDataExtent());
-                } else {
+                    vl.addFeatures(features, {
+                        silent: true
+                    });
+                    extent = vl.getDataExtent();
+                }
+                if (zoom) {
                     this.map.zoomToExtent(this.default_extend);
+                    if (this.value && this.default_zoom) {
+                        this.map.zoomTo(this.default_zoom);
+                    }
                 }
             }
         },

--- a/base_geoengine/static/src/js/geoengine_view.js
+++ b/base_geoengine/static/src/js/geoengine_view.js
@@ -225,6 +225,10 @@ openerp.base_geoengine = function(openerp) {
             }
             return this.alive(view_loaded_def).then(function(r) {
                 self.fields_view = r;
+                var data = r.geoengine_layers;
+                self.projection = data.projection;
+                self.restricted_extent = data.restricted_extent;
+                self.default_extent = data.default_extent;
                 return $.when(self.view_loading(r)).then(function() {
                     self.trigger('view_loaded', r);
                 });
@@ -531,6 +535,12 @@ openerp.base_geoengine = function(openerp) {
                 this.selectFeatureControls.select.setMap(map);
                 this.selectFeatureControls.select.handlers.map = map;
                 map.addControl(new OpenLayers.Control.ToolPanel());
+                if (this.restricted_extent) {
+                    map.restrictedExtent = OpenLayers.Bounds.fromString(this.restricted_extent);
+                    if (this.projection != map.getProjection()) {
+                        map.restrictedExtent = map.restrictedExtent.transform(this.projection, map.getProjection());
+                    }
+                }
                 map.zoomToMaxExtent();
                 this.map = map;
                 this.do_search(self.domains, null, self.offet);
@@ -755,7 +765,9 @@ openerp.base_geoengine = function(openerp) {
             rdataset.call("get_edit_info_for_geo_column", [self.name, rdataset.get_context()], false, 0).then(function(result) {
                 self.layers = self.create_edit_layers(self, result);
                 self.geo_type = result.geo_type;
+                self.projection = result.projection;
                 self.default_extent = result.default_extent;
+                self.restricted_extent = result.restricted_extent;
                 self.default_zoom = result.default_zoom;
                 self.srid = result.srid;
                 if (self.$el.is(':visible')){
@@ -802,10 +814,14 @@ openerp.base_geoengine = function(openerp) {
 
         render_map: function() {
             if (_.isNull(this.map)){
-                this.map = new OpenLayers.Map({
+                var map_opt = {
                     theme: null,
-                    layers: this.layers[0]
-                });
+                    layers: this.layers[0],
+                };
+                this.map = new OpenLayers.Map(map_opt);
+                if (this.restricted_extent) {
+                    this.map.restrictedExtent = OpenLayers.Bounds.fromString(this.restricted_extent).transform(this.projection, this.map.getProjection());
+                }
                 this.map.addLayer(this.layers[1]);
                 this.modify_control = new OpenLayers.Control.ModifyFeature(this.layers[1]);
                 if (this.geo_type == 'POINT' || this.geo_type == 'MULTIPOINT') {
@@ -826,7 +842,7 @@ openerp.base_geoengine = function(openerp) {
                 this.draw_control = new OpenLayers.Control.DrawFeature(this.layers[1], handler);
                 this.map.addControl(this.draw_control);
 
-                this.default_extend = OpenLayers.Bounds.fromString(this.default_extent).transform('EPSG:900913', this.map.getProjection());
+                this.default_extend = OpenLayers.Bounds.fromString(this.default_extent).transform(this.projection, this.map.getProjection());
                 this.map.zoomToExtent(this.default_extend);
                 this.format = new OpenLayers.Format.GeoJSON({
                     internalProjection: this.map.getProjection(),

--- a/base_geoengine/static/src/xml/geoengine.xml
+++ b/base_geoengine/static/src/xml/geoengine.xml
@@ -3,6 +3,9 @@
          <br />
         <div id="the_map"></div>
         <div id="map_infobox" class="map_overlay">
+            <div id="map_info_open">
+                <span class="fa fa-edit" />
+            </div>
             <div id="map_info"></div>
             <div id="map_info_filter_selection" class="oe_button">
               <span class="fa fa-filter"> Filter selection</span>


### PR DESCRIPTION
Backports of several improvements on base_geoengine from version 9.0:
1. Default zoom (can be specififed in the view) to open map on a specific zoom instead of zooming everytime by hand
2. Open related record - allows opening of the record connected to the geomap shape
3. Restricted extent and projection - allows change of projection and bound the map to an extent