### PR TITLE
[IMP] #4546 Now the partner is opened in a popup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ sudo: false
 cache: pip
 
 addons:
-  postgresql: 9.6
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
       - postgis postgresql-9.6-postgis-2.3 postgresql-9.6-postgis-2.3-scripts # because travis doesn't know which one to install
-before_script:
-  - psql -U postgres -c "create extension postgis"
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 cache: pip
 
 addons:
-  postgresql: 10
+  postgresql: 9.6
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ sudo: false
 cache: pip
 
 addons:
+  postgresql: 10
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
       - postgis postgresql-9.6-postgis-2.3 postgresql-9.6-postgis-2.3-scripts # because travis doesn't know which one to install
+before_script:
+  - psql -U postgres -c "create extension postgis"
 
 language: python
 

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -476,9 +476,11 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
         });
     },
     open_record: function (feature, options) {
-        oid = feature.attributes.id
-        if (this.dataset.select_id(oid)) {
+        this.oid = feature.attributes.id
+        if (this.dataset.select_id(this.oid)) {
             var self = this
+            var PartnerModel = new Model(this.dataset.model);
+            var ActWindowModel = new Model('ir.actions.act_window');
             new Model('ir.model.data').call(
                 'xmlid_to_res_id' , ['base.view_partner_form']
             ).then(function(view_id) {
@@ -486,7 +488,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                     type: 'ir.actions.act_window',
                     name: 'Partner details',
                     res_model: 'res.partner',
-                    res_id: self.dataset.ids[0],
+                    res_id: self.oid,
                     view_mode: 'form',
                     view_type: 'form',
                     views: [[view_id, 'form']],
@@ -499,7 +501,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 return self.do_action(action);
             })
         } else {
-            this.do_warn("Geoengine: could not find id#" + oid);
+            this.do_warn("Geoengine: could not find id#" + this.oid);
         }
     },
 

--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -16,6 +16,7 @@ odoo.define('base_geoengine.GeoengineView', function (require) {
 var core = require('web.core');
 var time = require('web.time');
 var View = require('web.View');
+var Model = require('web.DataModel')
 
 var geoengine_common = require('base_geoengine.geoengine_common');
 
@@ -477,7 +478,26 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
     open_record: function (feature, options) {
         oid = feature.attributes.id
         if (this.dataset.select_id(oid)) {
-            this.do_switch_view('form', null, options); //, null, { mode: "edit" });
+            var self = this
+            new Model('ir.model.data').call(
+                'xmlid_to_res_id' , ['base.view_partner_form']
+            ).then(function(view_id) {
+                var action = {
+                    type: 'ir.actions.act_window',
+                    name: 'Partner details',
+                    res_model: 'res.partner',
+                    res_id: self.dataset.ids[0],
+                    view_mode: 'form',
+                    view_type: 'form',
+                    views: [[view_id, 'form']],
+                    target: 'new',
+                    flags: {
+                        initial_mode: 'view',
+                    },
+                    context: {},
+                };
+                return self.do_action(action);
+            })
         } else {
             this.do_warn("Geoengine: could not find id#" + oid);
         }


### PR DESCRIPTION
In the 9.0 main branch when you click on a partner it will show you the formview, but when you go back to the map your zoom and position is lost.
We had a client that thought this behavior was inconvenient, he needed to see in sequence many customers of the same area and every time he opened one , he would have to zoom in again.
Here, customer is loaded in popup form , so that the map remains intact.
