### PR TITLE
[FIX] Remove mode/format='hex'

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -322,7 +322,7 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                         break;
                 }
                 var colors = [];
-                _.each(scale.colors(mode='hex'), function(color){
+                _.each(scale.colors(), function(color){
                     colors.push(chroma(color).alpha(opacity).css());
                 });
                 var styles_map = {};


### PR DESCRIPTION
Signed-off-by: Luis Felipe Mileo <mileo@kmee.com.br>

Without this fix i'm having this error with:

- Chromium Versão 70.0.3538.77 (Versão oficial) Arch Linux 64 bits
- Firerox 63.0.1 (64-bit)

![image](https://user-images.githubusercontent.com/1975978/49170429-3d246380-f323-11e8-9c12-8fcbe44581a3.png)
