### PR TITLE
[9.0] Fix CI build adding postgis and postgis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
+      - postgis postgresql-9.6-postgis-2.3 postgresql-9.6-postgis-2.3-scripts # because travis doesn't know which one to install
 
 language: python
 


### PR DESCRIPTION
Postgis scripts are included in travis build.
However, runbot doesn't pre-install them. Thus it needs to be set
explicitely.