### PR TITLE
[12.0] Fix selection of ttype field on ir.model.fields

### DIFF
--- a/base_geoengine/geo_ir/ir_model.py
+++ b/base_geoengine/geo_ir/ir_model.py
@@ -1,6 +1,6 @@
 # Copyright 2011-2012 Nicolas Bessi (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import fields, models
 from odoo.addons import base
 if 'geoengine' not in base.models.ir_actions.VIEW_TYPES:
     base.models.ir_actions.VIEW_TYPES.append(('geoengine', 'Geoengine'))

--- a/base_geoengine/geo_ir/ir_model.py
+++ b/base_geoengine/geo_ir/ir_model.py
@@ -23,15 +23,6 @@ POSTGIS_GEO_TYPES = [('POINT', 'POINT'),
 class IrModelField(models.Model):
     _inherit = 'ir.model.fields'
 
-    @api.model
-    def _get_fields_type(self):
-        cr = self._cr
-        cr.execute('SELECT DISTINCT ttype,ttype from ir_model_fields')
-        res = cr.fetchall()
-        to_return = list(set(res+GEO_TYPES))
-        to_return.sort()
-        return to_return
-
     srid = fields.Integer(
         'srid',
         required=False
@@ -48,7 +39,5 @@ class IrModelField(models.Model):
         'Create gist index'
     )
     ttype = fields.Selection(
-        '_get_fields_type',
-        'Field Type',
-        required=True
+        selection_add=GEO_TYPES,
     )


### PR DESCRIPTION
Replace the method by a the use of `selection_add` in order
to allow other modules to extend the list of field type.

Otherwise, it would crash on when installing for instance
both base_geoengine and base_sparse_field.