### PR TITLE
[9.0-ol3] base_geoengine: translation error with mail.tread inherit

### DIFF
--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -139,7 +139,8 @@ class GeoModel(models.BaseModel):
                     self.fields_get(cursor, uid, [geo_f_name]))
         else:
             return super(GeoModel, self).fields_view_get(
-                cursor, uid, view_id, view_type, context, toolbar, submenu)
+                cr=cursor, uid=uid, view_id=view_id, view_type=view_type,
+                context=context, toolbar=toolbar, submenu=submenu)
         return res
 
     def get_edit_info_for_geo_column(self, cursor, uid, column, context=None):


### PR DESCRIPTION
Add keyword argument on the super() call to fix the bug generated by old_api to new_api when a geo_model inherit mail.tread.

class ClassName(geo_model.GeoModel):
_name = 'model.name'
_inherit = ['mail.thread']

Same pull request than https://github.com/OCA/geospatial/pull/190 on branche 9.0