### PR TITLE
[12.0][IMP] Use default zoom when creating a map with no geometry

### DIFF
--- a/base_geoengine/static/src/js/widgets/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_widgets.js
@@ -120,7 +120,7 @@ odoo.define('base_geoengine.geoengine_widgets', function (require) {
             // Default extent
             if (map_view) {
                 var extent = this.defaultExtent.split(', ');
-                map_view.fit(extent, {maxZoom: 5});
+                map_view.fit(extent, {maxZoom: this.defaultZoom || 5});
             }
         },
 


### PR DESCRIPTION
When a map is created with no provided features (ie. no geometries), the default map extent is used to center the map. To do so the OpenLayers map view `fit()` function is used.
Currently a ``maxZoom`` option is passed to the function as well, limiting the actual zoom to the passed value. See the API doc at https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit

Currently the value of the passed ``maxZoom`` is hard-coded to 5.
Which is not always adapted, for instance when using the Swisstopo maps.

Here is what one gets when using the Switzerland extent as default extent with ``maxZoom=5``:

![Screenshot from 2019-10-31 11-55-24](https://user-images.githubusercontent.com/1192331/67941157-5b4eaf80-fbd5-11e9-897d-f88e03e477c5.png)
=> the map is way too zoomed out.

This PR suggests to use ``defaultZoom`` (already available in geoengine) as ``maxZoom``. With the example above, setting ``defaultZoom`` to 10 gives the following result:

![Screenshot from 2019-10-31 11-59-15](https://user-images.githubusercontent.com/1192331/67941451-ea5bc780-fbd5-11e9-8fbe-458d7258734c.png)
