### PR TITLE
[12.0] base_geoengine: fix tab listener after pager

### DIFF
--- a/base_geoengine/static/src/js/views/form_renderer.js
+++ b/base_geoengine/static/src/js/views/form_renderer.js
@@ -1,0 +1,19 @@
+odoo.define('base_geoengine.form_renderer', function (require) {
+    "use strict";
+
+    var FormRenderer = require('web.FormRenderer');
+
+    FormRenderer.include({
+        // _updateView refreshes the view after a pager action.
+        // Add the TabListener to geo_type widget so that _renderMap is called
+        // when clicking on the new tab
+        _updateView: function ($newContent) {
+            this._super.apply(this, arguments);
+            _.each(this.allFieldWidgets[this.state.id], function (widget) {
+                if (widget.field.geo_type) {
+                    widget._addTabListener()
+                }
+            });
+        }
+    });
+});

--- a/base_geoengine/static/src/js/widgets/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_widgets.js
@@ -109,7 +109,7 @@ odoo.define('base_geoengine.geoengine_widgets', function (require) {
                 return;
             }
             tab_link.on('shown.bs.tab', function (e) {
-                this._renderMap();
+                this._render();
             }.bind(this));
             this.tabListenerInstalled = true;
         },

--- a/base_geoengine/static/src/js/widgets/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_widgets.js
@@ -100,15 +100,18 @@ odoo.define('base_geoengine.geoengine_widgets', function (require) {
             if (this.tabListenerInstalled) {
                 return;
             }
-            this.tabListenerInstalled = true;
-
             var tab = this.$el.closest('div.tab-pane');
             if (!tab.length) {
                 return;
             }
-            $('a[href="#' + tab[0].id + '"]').on('shown.bs.tab', function (e) {
+            var tab_link = $('a[href="#' + tab[0].id + '"]')
+            if (!tab_link.length) {
+                return;
+            }
+            tab_link.on('shown.bs.tab', function (e) {
                 this._renderMap();
             }.bind(this));
+            this.tabListenerInstalled = true;
         },
 
         _parseValue: function (value) {

--- a/base_geoengine/views/base_geoengine_view.xml
+++ b/base_geoengine/views/base_geoengine_view.xml
@@ -19,6 +19,8 @@
                     src="/base_geoengine/static/src/js/views/geoengine/geoengine_view.js"/>
             <script type="text/javascript"
                     src="/base_geoengine/static/src/js/views/view_registry.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/views/form_renderer.js"/>
 
             <link rel="stylesheet"
                   href="/base_geoengine/static/src/css/style.css"/>


### PR DESCRIPTION
* When changing records using the pager the map wouldn't display due to not going through the event DOM_updated, thus we need an other way to add the tab listener in order to trigger the init of the map at the right time. Which is when the user clicks on a tab to open it. As only then we will know what is the dedicated space for the map.

* When displaying the map before editing it, a JS error was raised because the geometries layer were not loaded correctly on a tab switching action.