### PR TITLE
[12.0] Fix travis - Ignore false positive lint check E8103 and fix for BlockingIOError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,18 @@ env:
   - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"
   - TESTS="1" ODOO_REPO="OCA/OCB"
 
+before_install:
+
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install geojson Shapely sphinx sphinx_bootstrap_theme sphinx-intl odoo-sphinx-autodoc
+  # This is to solve an issue with stdout file descriptor
+  # raising a BlockingIOError while executing pylint and returns an exit -1
+  # seems related to the numerous lint errors on web_view_google_map module
+  # https://github.com/travis-ci/travis-ci/issues/8920
+  - /usr/bin/env python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 
 before_script:
   - if [ "$TESTS" -e "1" ] ; then psql -U postgres -d postgres -c "create extension postgis"; fi

--- a/base_geoengine/geo_db.py
+++ b/base_geoengine/geo_db.py
@@ -63,6 +63,9 @@ def create_geo_column(
                 geotype,
                 dim))
     if comment:
+        # TODO use SQL string Composition
+        # http://initd.org/psycopg/docs/sql.html
+        # pylint: disable=E8103
         cr.execute('COMMENT ON COLUMN "{}"."{}" IS %s'.format(
             tablename, columnname), (comment,))
     _schema.debug(
@@ -79,6 +82,8 @@ def create_geo_index(cr, columnname, tablename):
     indexname = _postgis_index_name(tablename, columnname)
     if sql.index_exists(cr, indexname):
         return
+    # TODO use SQL string Composition http://initd.org/psycopg/docs/sql.html
+    # pylint: disable=E8103
     cr.execute("CREATE INDEX %s ON %s USING GIST ( %s )" %
                (indexname,
                 tablename,

--- a/base_geoengine/geo_operators.py
+++ b/base_geoengine/geo_operators.py
@@ -113,6 +113,8 @@ def geo_search(model, domain=None, geo_domain=None, offset=0,
         where_statement = " WHERE %s" % (' '.join(where_clause_arr))
     else:
         where_statement = ''
+    # TODO use SQL string Composition http://initd.org/psycopg/docs/sql.html
+    # pylint: disable=E8103
     sql = 'SELECT "%s".id FROM ' % model._table + from_clause + \
         where_statement + order_by + limit_str + offset_str
     # logger.debug(cursor.mogrify(sql, where_clause_params))

--- a/base_geoengine_demo/models/geo_npa.py
+++ b/base_geoengine_demo/models/geo_npa.py
@@ -14,7 +14,7 @@ class NPA(models.Model):
     city = fields.Char('City', size=64, index=True, required=True)
     the_geom = fields.GeoMultiPolygon('NPA Shape')
     total_sales = fields.Float(
-        compute='_get_ZIP_total_sales',
+        compute='_compute_ZIP_total_sales',
         string='Spatial! Total Sales',
     )
     retail_machine_ids = fields.One2many(
@@ -24,7 +24,7 @@ class NPA(models.Model):
     )
 
     @api.multi
-    def _get_ZIP_total_sales(self):
+    def _compute_ZIP_total_sales(self):
         """Return the total of the invoiced sales for this npa"""
         mach_obj = self.env['geoengine.demo.automatic.retailing.machine']
         for rec in self:


### PR DESCRIPTION
Here the aim is to fix travis.

Currently pylint gives false positives
Once pylint-odoo accepts SQL string composition
we could rewrite the query.

Pylint-odoo issue tracked here:
https://github.com/OCA/pylint-odoo/issues/219

Those queries are low level and the parameters should be safe.

geo_search might need a double check.

Plus, probably related to numerous lint warnings on a module, we get a `BlockingIOError` (which doesn't appear on builds that targets only the modules that are more respectful to js lint guidelines)