### PR TITLE
[12.0] Define _descriptions to fix warnings

### DIFF
--- a/base_geoengine_demo/models/geo_npa.py
+++ b/base_geoengine_demo/models/geo_npa.py
@@ -8,6 +8,7 @@ class NPA(models.Model):
     """GEO OSV SAMPLE"""
 
     _name = "dummy.zip"
+    _description = "Geoengine demo ZIP"
 
     priority = fields.Integer('Priority', default=100)
     name = fields.Char('ZIP', size=64, index=True, required=True)

--- a/base_geoengine_demo/models/retail_machine.py
+++ b/base_geoengine_demo/models/retail_machine.py
@@ -8,6 +8,7 @@ class RetailMachine(models.Model):
     """GEO OSV SAMPLE"""
 
     _name = "geoengine.demo.automatic.retailing.machine"
+    _description = "Geoengine demo retailing machine"
 
     the_point = fields.GeoPoint('Coordinate')
     the_line = fields.GeoLine('Power supply line', index=True)


### PR DESCRIPTION
This PR aims to fix Runbot red status.

Warnings in logs are know to set Runbot status to :red_circle: 