### PR TITLE
[12.0][IMP] multi vector layers on geo_edit_map widget

### DIFF
--- a/base_geoengine/readme/USAGE.rst
+++ b/base_geoengine/readme/USAGE.rst
@@ -1,3 +1,25 @@
+Widget
+======
+
+The widget can be used on geometry fields::
+
+  <record id="some_model_form_view" model="ir.ui.view">
+    <field name="name">Some form view</field>
+    <field name="model">some.model</field>
+    <field name="arch" type="xml">
+      <form>
+      ...
+        <field name="geom1" widget="geo_edit_map" options="{'add_layer_fields': ['geom2']}"/>
+        <field name="geom2" invisible="1"/>
+      ...
+      </form>
+    </field>
+  </record>
+
+
+Options can contain other geometry fields to display them on the same map
+as a readonly layer.
+
 Important changes in version 11
 ===============================
 


### PR DESCRIPTION
This adds the capacity to add vector layers from other fields of the
record to the same geo widget.

To show additional layers on widget, use
options="{'add_layer_fields': ['field1', 'field2']}"

Here a widget with 5 geometries, in red the one that is the active editable layer.

![2020-04-29-092411_1129x586_scrot](https://user-images.githubusercontent.com/4158438/80570943-01039f80-89fc-11ea-925b-449539537707.png)


EDIT: screen capture of a widget