### PR TITLE
[IMP] base_geoengine: remove unnecessary hack

### DIFF
--- a/base_geoengine/geo_view/ir_view.py
+++ b/base_geoengine/geo_view/ir_view.py
@@ -1,25 +1,14 @@
 # Copyright 2011-2012 Nicolas Bessi (Camptocamp SA)
 # Copyright 2016 Yannick Vaucher (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import fields, models
 
-GEO_VIEW = ("geoengine", "GeoEngine")
 
 
 class IrUIView(models.Model):
     _inherit = "ir.ui.view"
 
-    @api.model
-    def _setup_fields(self):
-        """Hack due since the field 'type' is not defined with the new api.
-        """
-        cls = type(self)
-        type_selection = cls._fields["type"].selection
-        if GEO_VIEW not in type_selection:
-            tmp = list(type_selection)
-            tmp.append(GEO_VIEW)
-            cls._fields["type"].selection = tuple(set(tmp))
-        super()._setup_fields()
+    type = fields.Selection(selection_add=[("geoengine", "GeoEngine")])
 
     raster_layer_ids = fields.One2many(
         "geoengine.raster.layer", "view_id", "Raster layers", required=False


### PR DESCRIPTION
This hack is not needed anymore, and it cause an UI problem: the option 'geoengine' is not suggested in the selection list (backend views)

illustration:

Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/13518832/81950972-e38e2280-9604-11ea-97c3-42e09c3c3d75.png) | ![image](https://user-images.githubusercontent.com/13518832/81951057-fc96d380-9604-11ea-8575-03d39992d428.png)

