### PR TITLE
[FW] [13.0] Fix default_extent in views

### DIFF
--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -133,7 +133,7 @@ class GeoModel(models.AbstractModel):
             "srid": field.srid,
             "projection": view.projection,
             "restricted_extent": view.restricted_extent,
-            "default_extent": view.default_extent,
+            "default_extent": view.default_extent or DEFAULT_EXTENT,
             "default_zoom": view.default_zoom,
         }
 

--- a/base_geoengine/static/src/js/widgets/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_widgets.js
@@ -122,7 +122,8 @@ odoo.define('base_geoengine.geoengine_widgets', function (require) {
             var map_view = this.map.getView();
             // Default extent
             if (map_view) {
-                var extent = this.defaultExtent.split(', ');
+                var extent = this.defaultExtent.replace(/\s/g, '').split(',');
+                extent = extent.map(coord => Number(coord));
                 map_view.fit(extent, {maxZoom: this.defaultZoom || 5});
             }
         },


### PR DESCRIPTION
Forward port of  #257

Convert the extent information from string to number when opening an
empty view.
Although the default_extent is set with a default value on creation, the
field can be set to null so make sure a default value is used.

Co-authored-by: Yannick Vaucher <yannick.vaucher@camptocamp.com>