### PR TITLE
[10.0][IMP] base_geoengine: allow custom configuration on layer opacity

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine_view.js
+++ b/base_geoengine/static/src/js/views/geoengine_view.js
@@ -61,6 +61,11 @@ var formatFeatureHTML = function(a, fields) {
             if (fields.hasOwnProperty(key)) {
                 var field = fields[key];
                 var label = field.string;
+
+                if (field.type.startsWith('geo_')) {
+                    continue;
+                }
+
                 if (field.type === 'selection') {
                     // get display value of selection option
                     for (var option in field.selection) {
@@ -416,12 +421,13 @@ var GeoengineView = View.extend(geoengine_common.GeoengineMixin, {
                 });
                 var olStyleText = new ol.style.Text({
                     text: "",
+                    font: '12px Arial',
                     fill: new ol.style.Fill({
                       color: "#000000"
                     }),
                     stroke: new ol.style.Stroke({
                       color: "#FFFFFF",
-                      width: 2
+                      width: 10
                     })
                 });
                 var styles = [

--- a/base_geoengine/static/src/js/views/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/views/geoengine_widgets.js
@@ -34,11 +34,12 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
     create_vector_layer: function(self) {
         this.features = new ol.Collection();
         this.source = new ol.source.Vector({features: this.features});
-        return new ol.layer.Vector({
+
+        var vl = new ol.layer.Vector({
             source: this.source,
             style: new ol.style.Style({
                 fill: new ol.style.Fill({
-                    color: '#ee9900',
+                    color: (!!this.options && this.options.fill_color) ?  this.options.fill_color :'#ee9900',
                     opacity: 0.7,
                 }),
                 stroke: new ol.style.Stroke({
@@ -54,10 +55,17 @@ var FieldGeoEngineEditMap = common.AbstractField.extend(geoengine_common.Geoengi
                 }),
             })
         });
+
+        if (!!this.options && this.options.opacity) {
+            vl.setOpacity(this.options.opacity)
+        }
+        
+        return vl;
     },
 
     create_layers: function(self, field_infos) {
         this.vector_layer = this.create_vector_layer();
+
         this.raster_layers = this.createBackgroundLayers([field_infos.edit_raster]);
         this.raster_layers[0].isBaseLayer = true;
     },

--- a/base_geoengine_demo/views/zip.xml
+++ b/base_geoengine_demo/views/zip.xml
@@ -16,7 +16,7 @@
         </group>
         <notebook colspan="4">
           <page string="Geometry">
-            <field name="the_geom" colspan="4" widget="geo_edit_map"/>
+            <field name="the_geom" colspan="4" widget="geo_edit_map" options='{"opacity": 0.4, "fill_color":"#33ccff"}'/>
           </page>
         </notebook>
         <field name="total_sales"/>


### PR DESCRIPTION
into the view definition, you can now specify 2 options on the geofield. Opacity (for the layer) and a fill_color
ex:
<field name="geofield" widget="geo_edit_map"
 options='{"opacity": 0.4, "fill_color":"#33ccff"}'/>