### PR TITLE
[FIX] web_view_google_map: JS Files

### DIFF
--- a/web_view_google_map/views/google_places_template.xml
+++ b/web_view_google_map/views/google_places_template.xml
@@ -26,6 +26,10 @@
             <script type="text/javascript" src="/web_view_google_map/static/src/js/view/map/map_renderer.js"></script>
             <script type="text/javascript" src="/web_view_google_map/static/src/js/view/map/map_view.js"></script>
             <script type="text/javascript" src="/web_view_google_map/static/src/js/view/view_registry.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/fields/relational_fields.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/widgets/utils.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/widgets/gplaces_autocomplete.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/widgets/fields_registry.js"></script>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
We need to include these files if we want to be able to use the google address autocomplete widget. If these are included elsewhere please let me know as we have a few modules that depend on this module and are missing these .js files