### PR TITLE
[IMP] web_view_google_map: Separate API keys for Geocode/Autocomplete

### DIFF
--- a/base_google_map/models/res_config_settings.py
+++ b/base_google_map/models/res_config_settings.py
@@ -97,6 +97,8 @@ class ResConfigSettings(models.TransientModel):
         return values
 
     google_maps_view_api_key = fields.Char(string='Google Maps View Api Key')
+    google_autocomplete_api_key = fields.Char(string='Google Autocomplete Api Key')
+
     google_maps_lang_localization = fields.Selection(
         selection=GMAPS_LANG_LOCALIZATION,
         string='Google Maps Language Localization')
@@ -139,6 +141,8 @@ class ResConfigSettings(models.TransientModel):
 
         ICPSudo.set_param('google.api_key_geocode',
                           self.google_maps_view_api_key)
+        ICPSudo.set_param('google.fsm_key_autocomplete',
+                          self.google_autocomplete_api_key)
         ICPSudo.set_param('google.lang_localization',
                           lang_localization)
         ICPSudo.set_param('google.region_localization',
@@ -160,6 +164,8 @@ class ResConfigSettings(models.TransientModel):
         res.update({
             'google_maps_view_api_key': ICPSudo.get_param(
                 'google.api_key_geocode', default=''),
+            'google_autocomplete_api_key': ICPSudo.get_param(
+                'google.fsm_key_autocomplete', default=''),
             'google_maps_lang_localization': lang_localization,
             'google_maps_region_localization': region_localization,
             'google_maps_theme': ICPSudo.get_param(

--- a/base_google_map/views/res_config_settings.xml
+++ b/base_google_map/views/res_config_settings.xml
@@ -20,8 +20,12 @@
                                     </div>
                                     <div class="content-group">
                                         <div class="mt16">
-                                            <label for="google_maps_view_api_key" string="Api key"/>
+                                            <label for="google_maps_view_api_key" string="Google Maps Api key"/>
                                             <field name="google_maps_view_api_key"/>
+                                        </div>
+                                        <div class="mt16">
+                                            <label for="google_autocomplete_api_key" string="Google Autocomplete Api key"/>
+                                            <field name="google_autocomplete_api_key"/>
                                         </div>
                                         <div class="mt16">
                                             <label for="google_maps_theme" string="Theme"/>

--- a/web_view_google_map/__init__.py
+++ b/web_view_google_map/__init__.py
@@ -2,3 +2,5 @@
 
 from . import models
 from .hooks import uninstall_hook
+from .hooks import pre_init_hook
+from .hooks import post_init_hook

--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Google Map View',
     'summary': 'Add a Google Map view type to the Odoo web client',
-    'version': '12.0.1.1.1',
+    'version': '12.0.2.0.0',
     'author': 'Open Source Integrators, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/geospatial',
     'license': 'AGPL-3',
@@ -14,12 +14,16 @@
         'contacts',
     ],
     'data': [
+        'data/google_maps_libraries.xml',
+        'data/ir_config_parameter.xml',
         'views/google_places_template.xml',
         'views/res_partner.xml',
     ],
     'images': ['static/description/thumbnails.png'],
     'qweb': ['static/src/xml/widget_places.xml'],
     'installable': True,
+    'pre_init_hook': 'pre_init_hook',
+    'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'maintainers': [
         'gityopie',

--- a/web_view_google_map/data/google_maps_libraries.xml
+++ b/web_view_google_map/data/google_maps_libraries.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <function model="ir.config_parameter" name="set_param" eval="('google.maps_libraries', 'geometry,places')"/>
+    </data>
+</odoo>

--- a/web_view_google_map/data/ir_config_parameter.xml
+++ b/web_view_google_map/data/ir_config_parameter.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <data noupdate="1">
+    	<record id="google_geocode_parameter" model="ir.config_parameter">
+            <field name="key">google.api_key_geocode</field>
+            <field name="value"></field>
+        </record>
+        <record id="google_autocomplete_parameter" model="ir.config_parameter">
+            <field name="key">google.fsm_key_autocomplete</field>
+            <field name="value"></field>
+        </record>
+    </data>
+</odoo>

--- a/web_view_google_map/hooks.py
+++ b/web_view_google_map/hooks.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2019, Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
+from odoo import api, SUPERUSER_ID
 
 def uninstall_hook(cr, registry):
     cr.execute("UPDATE ir_act_window "
@@ -11,3 +11,36 @@ def uninstall_hook(cr, registry):
                "WHERE view_mode LIKE '%map,%';")
     cr.execute("DELETE FROM ir_act_window "
                "WHERE view_mode = 'map';")
+
+def pre_init_hook(cr):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    config_params = env['ir.config_parameter'].\
+        search([('key', 'in', ['google.api_key_geocode',
+                               'google.fsm_key_autocomplete'])])
+    if config_params:
+        for param in config_params:
+            if param.key == 'google.api_key_geocode':
+                val = param.value
+                param.unlink()
+                env['ir.config_parameter'].create({'key': 'temp_key_geo', 'value': val})
+            else:
+                val = param.value
+                param.unlink()
+                env['ir.config_parameter'].create({'key': 'temp_key_auto', 'value': val})
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    config_params = env['ir.config_parameter'].\
+        search([('key', 'in', ['temp_key_geo',
+                               'temp_key_auto'])])
+    if config_params:
+        for param in config_params:
+            if param.key == 'temp_key_geo':
+                geocode = env.ref('web_view_google_map.google_geocode_parameter')
+                geocode.write({'value': param.value})
+                param.unlink()
+            else:
+                geocode = env.ref('web_view_google_map.google_autocomplete_parameter')
+                geocode.write({'value': param.value})
+                param.unlink()

--- a/web_view_google_map/migrations/12.0.2.0.0/post-migration.py
+++ b/web_view_google_map/migrations/12.0.2.0.0/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2020 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, SUPERUSER_ID
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    config_params = env['ir.config_parameter'].\
+        search([('key', 'in', ['temp_key_geo',
+                               'temp_key_auto'])])
+    if config_params:
+        for param in config_params:
+            if param.key == 'temp_key_geo':
+                geocode = env.ref('web_view_google_map.google_geocode_parameter')
+                geocode.write({'value': param.value})
+                param.unlink()
+            else:
+                geocode = env.ref('web_view_google_map.google_autocomplete_parameter')
+                geocode.write({'value': param.value})
+                param.unlink()

--- a/web_view_google_map/migrations/12.0.2.0.0/pre-migration.py
+++ b/web_view_google_map/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2020 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    config_params = env['ir.config_parameter'].\
+        search([('key', 'in', ['google.api_key_geocode',
+                               'google.fsm_key_autocomplete'])])
+    if config_params:
+        for param in config_params:
+            if param.key == 'google.api_key_geocode':
+                val = param.value
+                param.unlink()
+                env['ir.config_parameter'].create({'key': 'temp_key_geo', 'value': val})
+            else:
+                val = param.value
+                param.unlink()
+                env['ir.config_parameter'].create({'key': 'temp_key_auto', 'value': val})

--- a/web_view_google_map/static/src/js/widgets/gplaces_autocomplete.js
+++ b/web_view_google_map/static/src/js/widgets/gplaces_autocomplete.js
@@ -90,8 +90,8 @@ odoo.define('web_view_google_map.GplaceAutocompleteFields', function (require) {
                         center: geolocation,
                         radius: position.coords.accuracy
                     });
-
-                    self.places_autocomplete.setBounds(circle.getBounds());
+                    // Temporary Comment
+                    // self.places_autocomplete.setBounds(circle.getBounds());
                 });
             }
         },
@@ -201,7 +201,7 @@ odoo.define('web_view_google_map.GplaceAutocompleteFields', function (require) {
             this._super.apply(this, arguments);
             this.fillfields = {
                 [this.address_form.street]: ['street_number', 'route'],
-                [this.address_form.street2]: ['administrative_area_level_3', 'administrative_area_level_4', 'administrative_area_level_5'],
+                // [this.address_form.street2]: ['administrative_area_level_3', 'administrative_area_level_4', 'administrative_area_level_5'],
                 [this.address_form.city]: ['locality', 'administrative_area_level_2'],
                 [this.address_form.zip]: 'postal_code',
                 [this.address_form.state_id]: 'administrative_area_level_1',
@@ -329,11 +329,11 @@ odoo.define('web_view_google_map.GplaceAutocompleteFields', function (require) {
                 general: {
                     name: 'name',
                     website: 'website',
-                    phone: ['international_phone_number', 'formatted_phone_number']
+                    // phone: ['international_phone_number', 'formatted_phone_number']
                 },
                 address: {
                     street: ['street_number', 'route'],
-                    street2: ['administrative_area_level_3', 'administrative_area_level_4', 'administrative_area_level_5'],
+                    // street2: ['administrative_area_level_3', 'administrative_area_level_4', 'administrative_area_level_5'],
                     city: ['locality', 'administrative_area_level_2'],
                     zip: 'postal_code',
                     state_id: 'administrative_area_level_1',
@@ -438,7 +438,7 @@ odoo.define('web_view_google_map.GplaceAutocompleteFields', function (require) {
             setTimeout(function () {
                 if (!self.places_autocomplete) {
                     self.places_autocomplete = new google.maps.places.Autocomplete(self.$input.get(0), {
-                        types: ['establishment']
+                        types: []
                     });
                 }
                 // When the user selects an address from the dropdown, populate the address fields in the form.

--- a/web_view_google_map/views/google_places_template.xml
+++ b/web_view_google_map/views/google_places_template.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <template id="assets_gmaps" name="Assets backend Google Map">
-        <t t-set="google_maps_api_key" t-value="request.env['ir.config_parameter'].sudo().get_param('google.api_key_geocode')"/>
+        <t t-set="google_maps_api_key" t-value="request.env['ir.config_parameter'].sudo().get_param('google.fsm_key_autocomplete')"/>
         <t t-set="google_maps_lang_localization" t-value="request.env['ir.config_parameter'].sudo().get_param('google.lang_localization')"/>
         <t t-set="google_maps_region_localization" t-value="request.env['ir.config_parameter'].sudo().get_param('google.region_localization')"/>
+        <t t-set="google_maps_libraries" t-value="request.env['ir.config_parameter'].sudo().get_param('google.maps_libraries')"/>
         <script src="/web_view_google_map/static/lib/markercluster/markerclusterer.js"></script>
         <t t-if="google_maps_api_key">
             <script t-attf-src="https://maps.googleapis.com/maps/api/js?v=quarterly&amp;libraries=geometry,places&amp;key=#{google_maps_api_key}&amp;#{google_maps_lang_localization}#{google_maps_region_localization}"></script>
@@ -26,6 +27,10 @@
             <script type="text/javascript" src="/web_view_google_map/static/src/js/view/map/map_renderer.js"></script>
             <script type="text/javascript" src="/web_view_google_map/static/src/js/view/map/map_view.js"></script>
             <script type="text/javascript" src="/web_view_google_map/static/src/js/view/view_registry.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/fields/relational_fields.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/widgets/utils.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/widgets/gplaces_autocomplete.js"></script>
+            <script type="text/javascript" src="/web_view_google_map/static/src/js/widgets/fields_registry.js"></script>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
The Google Address Autocomplete widget uses different security protocols than the Geocoding Api calls. This PR allows you to use 2 keys however it is still in draft because ideally we only want to have 1 key.