### PR TITLE
[IMP] base_geoengine: make geoengine rights implied by standard usage…

### DIFF
--- a/base_geoengine/security/data.xml
+++ b/base_geoengine/security/data.xml
@@ -11,4 +11,18 @@
         <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>
 
+    <record id="base.group_user" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(4, ref('base_geoengine.group_geoengine_user'))]"
+        />
+    </record>
+
+    <record id="base.group_system" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(4, ref('base_geoengine.group_geoengine_admin'))]"
+        />
+    </record>
+
 </odoo>


### PR DESCRIPTION
… groups

Before, installing base_geoengine makes all users except root_user to not
have access to contacts because they do not have access to geoengine models.
Users should not need new rights to perform old activities.
Therefore we make base.group_user imply user rights.
For ease of use, the Geoengine admin group is made implied by group_system.