### PR TITLE
[FIX] vertex layer label (generalize to all layer types)

### DIFF
--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -1,5 +1,6 @@
 # Copyright 2011-2012 Nicolas Bessi (Camptocamp SA)
-# Copyright 2016 Yannick Vaucher (Camptocamp SA)
+# Copyright 2016-2021 Yannick Vaucher (Camptocamp SA)
+# Copyright 2021 Stephane Mangin (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, models
 from odoo.exceptions import MissingError, except_orm
@@ -96,6 +97,9 @@ class GeoModel(models.AbstractModel):
                     )
                 layer_dict["attribute_field_id"] = set_field_real_name(
                     layer_dict.get("attribute_field_id", False)
+                )
+                layer_dict["label_field_id"] = set_field_real_name(
+                    layer_dict.get("label_field_id", False)
                 )
                 layer_dict["geo_field_id"] = set_field_real_name(
                     layer_dict.get("geo_field_id", False)

--- a/base_geoengine/geo_view/geo_vector_layer.py
+++ b/base_geoengine/geo_view/geo_vector_layer.py
@@ -1,5 +1,6 @@
 # Copyright 2011-2012 Nicolas Bessi (Camptocamp SA)
-# Copyright 2016 Yannick Vaucher (Camptocamp SA)
+# Copyright 2016-2021 Yannick Vaucher (Camptocamp SA)
+# Copyright 2021 Stephane Mangin (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
@@ -52,6 +53,9 @@ class GeoVectorLayer(models.Model):
     nb_class = fields.Integer("Number of class", default=1)
     attribute_field_id = fields.Many2one(
         "ir.model.fields", "attribute field", domain=[("ttype", "in", SUPPORTED_ATT)]
+    )
+    label_field_id = fields.Many2one(
+        "ir.model.fields", "label field", domain=[("ttype", "in", SUPPORTED_ATT)]
     )
     geo_field_id = fields.Many2one(
         "ir.model.fields",

--- a/base_geoengine/geo_view/geo_vector_layer_view.xml
+++ b/base_geoengine/geo_view/geo_vector_layer_view.xml
@@ -14,6 +14,10 @@
                         name="attribute_field_id"
                         attrs="{'required': [('geo_repr', 'in', ['choropleth', 'proportion', 'colored'])]}"
                     />
+                    <field
+                        name="label_field_id"
+                        attrs="{'required': [('display_polygon_labels', '=', True ),]}"
+                    />
                     <field name="active_on_startup" />
                     <field name="display_polygon_labels" />
                     <field name="sequence" />
@@ -73,6 +77,7 @@
                 <field name="classification" select="1" />
                 <field name="geo_field_id" select="1" />
                 <field name="attribute_field_id" select="1" />
+                <field name="label_field_id" select="1" />
                 <field name="active_on_startup" />
                 <field name="sequence" />
             </tree>

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer.js
@@ -301,7 +301,7 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                     });
 
                     if (cfg.display_polygon_labels === true) {
-                        attributes.label = item[cfg.attribute_field_id[1]];
+                        attributes.label = item.data[cfg.label_field_id[1]];
                     } else {
                         attributes.label = "";
                     }
@@ -331,6 +331,7 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                 title: cfg.name,
                 active_on_startup: cfg.active_on_startup,
                 style: styleInfo.style,
+                declutter: true,
             });
             lv.on("change:visible", function() {
                 if (lv.getVisible()) {
@@ -353,6 +354,24 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                 values.push(item.data[indicator]);
             });
             return values;
+        },
+
+        _createTextStyle: function(feature) {
+            var label_text = feature.values_.attributes.label;
+            if (label_text === false) {
+                label_text = "";
+            }
+            return new ol.style.Text({
+                text: label_text,
+                fill: new ol.style.Fill({
+                    color: "#000000",
+                }),
+                stroke: new ol.style.Stroke({
+                    color: "#FFFFFF",
+                    width: 5,
+                }),
+                overflow: true,
+            });
         },
 
         _styleVectorLayerColored: function(cfg, data) {
@@ -432,6 +451,7 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                         }),
                         fill: fill,
                         stroke: stroke,
+                        text: "",
                     }),
                 ];
                 styles_map[color] = styles;
@@ -445,7 +465,9 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                 style: function(feature) {
                     var value = feature.get("attributes")[indicator];
                     var color_idx = this._getClass(value, vals);
-                    return styles_map[colors[color_idx]];
+                    var styles = styles_map[colors[color_idx]];
+                    styles[0].setText(this._createTextStyle(feature));
+                    return styles;
                 }.bind(this),
                 legend: legend,
             };
@@ -489,6 +511,7 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                         }),
                         fill: fill,
                         stroke: stroke,
+                        text: "",
                     }),
                 ];
                 styles_map[value] = styles;
@@ -497,8 +520,10 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
             return {
                 style: function(feature) {
                     var value = feature.get("attributes")[indicator];
-                    return styles_map[value];
-                },
+                    var styles = styles_map[value];
+                    styles[0].setText(this._createTextStyle(feature));
+                    return styles;
+                }.bind(this),
                 legend: "",
             };
         },
@@ -518,16 +543,6 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                 color: "#333333",
                 width: 2,
             });
-            var olStyleText = new ol.style.Text({
-                text: "",
-                fill: new ol.style.Fill({
-                    color: "#000000",
-                }),
-                stroke: new ol.style.Stroke({
-                    color: "#FFFFFF",
-                    width: 5,
-                }),
-            });
             var styles = [
                 new ol.style.Style({
                     image: new ol.style.Circle({
@@ -537,18 +552,14 @@ odoo.define("base_geoengine.GeoengineRenderer", function(require) {
                     }),
                     fill: fill,
                     stroke: stroke,
-                    text: olStyleText,
+                    text: "",
                 }),
             ];
             return {
                 style: function(feature) {
-                    var label_text = feature.values_.attributes.label;
-                    if (label_text === false) {
-                        label_text = "";
-                    }
-                    styles[0].text_.text_ = label_text;
+                    styles[0].setText(this._createTextStyle(feature));
                     return styles;
-                },
+                }.bind(this),
                 legend: "",
             };
         },


### PR DESCRIPTION
Problem encountered:
Labels on vertex layers by feature was not working anymore (assuming since the version 12 or 10)
Despite the fact that a boolean field called display label was still present in the code, this behavior was totally broken.

This issue has been addressed and label display is now available to all custom types of vertex layer's by feature (basic, colored, proportion)
