### PR TITLE
[13.0][FIX] base_geoengine - fix deprecation about asShape()

### DIFF
--- a/base_geoengine/geo_helper/geo_convertion_helper.py
+++ b/base_geoengine/geo_helper/geo_convertion_helper.py
@@ -5,7 +5,7 @@ import logging
 try:
     import geojson
     from shapely import wkb, wkt
-    from shapely.geometry import asShape
+    from shapely.geometry import shape
     from shapely.geometry.base import BaseGeometry
 except ImportError:
     logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ def value_to_shape(value, use_wkb=False):
         # exception are ressource costly
         if "{" in value:
             geo_dict = geojson.loads(value)
-            return asShape(geo_dict)
+            return shape(geo_dict)
         elif use_wkb:
             return wkb.loads(value, hex=True)
         else:


### PR DESCRIPTION
Hi,

When using a fieldservice module, I get this in my logs : 
WARNING odoo-eri-394739 py.warnings: /venv/lib/python3.6/site-packages/odoo/addons/base_geoengine/geo_helper/geo_convertion_helper.py:24: ShapelyDeprecationWarning: The proxy geometries (through the 'asShape()', 'asPoint()' or 'PointAdapter()' constructors) are deprecated and will be removed in Shapely 2.0. Use the 'shape()' function or the standard 'Point()' constructor instead.
  return asShape(geo_dict)

Following the warning advice, I changed asShape() with shape()