### PR TITLE
[9.0] [FIX] base_geoengine: correct arguments for fields_view_get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
@@ -32,7 +35,7 @@ env:
 
 
 install:
-  - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install geojson Shapely sphinx sphinx_bootstrap_theme sphinx-intl odoo-sphinx-autodoc

--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -87,7 +87,7 @@ class GeoModel(models.BaseModel):
                 _('Please create a view or modify view mode'))
         return view_obj.browse(cursor, uid, geo_view_id[0])
 
-    def fields_view_get(self, cursor, uid, view_id=None, view_type='form',
+    def fields_view_get(self, cr, uid, view_id=None, view_type='form',
                         context=None, toolbar=False, submenu=False):
         """Returns information about the available fields of the class.
            If view type == 'map' returns geographical columns available"""
@@ -99,16 +99,16 @@ class GeoModel(models.BaseModel):
         def set_field_real_name(in_tuple):
             if not in_tuple:
                 return in_tuple
-            name = field_obj.read(cursor, uid, in_tuple[0], ['name'])['name']
+            name = field_obj.read(cr, uid, in_tuple[0], ['name'])['name']
             out = (in_tuple[0], name, in_tuple[1])
             return out
         if view_type == "geoengine":
             if not view_id:
-                view = self._get_geo_view(cursor, uid)
+                view = self._get_geo_view(cr, uid)
             else:
-                view = view_obj.browse(cursor, uid, view_id)
+                view = view_obj.browse(cr, uid, view_id)
             res = super(GeoModel, self).fields_view_get(
-                cursor, uid, view.id, 'form', context, toolbar, submenu)
+                cr, uid, view.id, 'form', context, toolbar, submenu)
             res['geoengine_layers'] = {}
             res['geoengine_layers']['backgrounds'] = []
             res['geoengine_layers']['actives'] = []
@@ -120,10 +120,10 @@ class GeoModel(models.BaseModel):
             res['geoengine_layers']['default_zoom'] = view.default_zoom
             # TODO find why context in read does not work with webclient
             for layer in view.raster_layer_ids:
-                layer_dict = raster_obj.read(cursor, uid, layer.id)
+                layer_dict = raster_obj.read(cr, uid, layer.id)
                 res['geoengine_layers']['backgrounds'].append(layer_dict)
             for layer in view.vector_layer_ids:
-                layer_dict = vector_obj.read(cursor, uid, layer.id)
+                layer_dict = vector_obj.read(cr, uid, layer.id)
                 # get category groups for this vector layer
                 if layer.geo_repr == 'basic':
                     layer_dict['symbols'] = layer.symbol_ids.read(
@@ -136,11 +136,12 @@ class GeoModel(models.BaseModel):
                 # adding geo column desc
                 geo_f_name = layer_dict['geo_field_id'][1]
                 res['fields'].update(
-                    self.fields_get(cursor, uid, [geo_f_name]))
+                    self.fields_get(cr, uid, [geo_f_name]))
         else:
             return super(GeoModel, self).fields_view_get(
-                cr=cursor, uid=uid, view_id=view_id, view_type=view_type,
-                context=context, toolbar=toolbar, submenu=submenu)
+                cr, uid, view_id=view_id, view_type=view_type,
+                context=context, toolbar=toolbar, submenu=submenu
+            )
         return res
 
     def get_edit_info_for_geo_column(self, cursor, uid, column, context=None):


### PR DESCRIPTION
When installing base_geoengine and then geoengine_partner you will, without this PR, get an exception like so:

```
Odoo Server Error
Traceback (most recent call last):
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 659, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 332, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 325, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 975, in __call__
    return self.method(*args, **kw)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 525, in response_wrap
    response = f(*args, **kw)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/addons/web/controllers/main.py", line 1174, in load
    action = request.session.model(action_type).read([action_id], False, ctx)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/http.py", line 1080, in proxy
    result = meth(cr, request.uid, *args, **kw)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/addons/base/ir/ir_actions.py", line 370, in read
    results = super(ir_actions_act_window, self).read(cr, uid, ids, fields=fields, context=context, load=load)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/models.py", line 3209, in read
    result = BaseModel.read(records, fields, load=load)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/models.py", line 3244, in read
    self._read_from_database(stored, inherited)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/models.py", line 3435, in _read_from_database
    res2 = self._columns[f].get(cr, self._model, ids, f, user, context=context, values=result)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/osv/fields.py", line 1506, in get
    result = self._fnct(obj, cr, uid, ids, name, self._arg, context)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/addons/base/ir/ir_actions.py", line 312, in _search_view
    'search', context=context)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/geospatial/base_geoengine/geo_model.py", line 143, in fields_view_get
    context=context, toolbar=toolbar, submenu=submenu)
  File "/home/openeyedev/var/projects/spinpompen_9011/odoo/parts/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
TypeError: fields_view_get() got an unexpected keyword argument 'uid' 
```