### PR TITLE
[12.0][FIX] Name and order of parameters of the gist index creation function

### DIFF
--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -8,7 +8,7 @@ from odoo import fields, _
 from odoo.tools import sql
 
 from .geo_helper import geo_convertion_helper as convert
-from .geo_db import create_geo_column
+from .geo_db import create_geo_column, create_geo_index
 
 logger = logging.getLogger(__name__)
 try:
@@ -145,7 +145,7 @@ class GeoField(fields.Field):
             index = cr.fetchone()
             if index:
                 return True
-            self._create_index(cr, model._table, self.name)
+            create_geo_index(cr, model._table, self.name)
         return True
 
     def update_db_column(self, model, column):

--- a/base_geoengine/geo_db.py
+++ b/base_geoengine/geo_db.py
@@ -77,7 +77,7 @@ def _postgis_index_name(table, col_name):
     return "%s_%s_gist_index" % (table, col_name)
 
 
-def create_geo_index(cr, columnname, tablename):
+def create_geo_index(cr, tablename, columnname):
     """ Create the given index unless it exists. """
     indexname = _postgis_index_name(tablename, columnname)
     if sql.index_exists(cr, indexname):


### PR DESCRIPTION
It's been a while since spatial indexes could not be created on geographic fields. This commit correctly uses the nomenclature of the functions and the parameters to use.