### PR TITLE
[14.0][FIX]base_geoengine: require Shapely<2

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -51,7 +51,7 @@ repo_description: 'This project will enable real life GIS support on Odoo.
 
     * System: *  **PostGIS** http://postgis.refractions.net/
 
-    * Python: *  **Shapely** http://pypi.python.org/pypi/Shapely
+    * Python: *  **Shapely** http://pypi.python.org/pypi/Shapely  (not yet compatible with v2.0)
 
     *  **geojson** http://pypi.python.org/pypi/geojson'
 repo_name: Geospatial Addons for Odoo

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A geospatial API is provided, to add your own functionalites at your convenience
 
 * System: *  **PostGIS** http://postgis.refractions.net/
 
-* Python: *  **Shapely** http://pypi.python.org/pypi/Shapely
+* Python: *  **Shapely** http://pypi.python.org/pypi/Shapely (not yet compatible with v2.0)
 
 *  **geojson** http://pypi.python.org/pypi/geojson
 

--- a/base_geoengine/README.rst
+++ b/base_geoengine/README.rst
@@ -45,7 +45,7 @@ On Ubuntu::
 
 The module also requires two additional python libs:
 
-* `Shapely <http://pypi.python.org/pypi/Shapely>`_
+* `Shapely<2 <http://pypi.python.org/pypi/Shapely>`_
 
 * `geojson <http://pypi.python.org/pypi/geojson>`_
 

--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -18,7 +18,7 @@
         "geo_view/geo_vector_layer_view.xml",
         "security/ir.model.access.csv",
     ],
-    "external_dependencies": {"python": ["shapely", "geojson", "simplejson"]},
+    "external_dependencies": {"python": ["shapely<2", "geojson", "simplejson"]},
     "qweb": ["static/src/xml/geoengine.xml"],
     "installable": True,
     "pre_init_hook": "init_postgis",

--- a/base_geoengine/doc/build/_sources/prerequisite.txt
+++ b/base_geoengine/doc/build/_sources/prerequisite.txt
@@ -14,7 +14,7 @@ Shapely:
 
 ::
 
- pip install Shapely==1.2.13
+ pip install Shapely<2
 
 For Mac user: do not forget the following directive:
 

--- a/base_geoengine/doc/build/prerequisite.html
+++ b/base_geoengine/doc/build/prerequisite.html
@@ -74,7 +74,7 @@
                 <div class="highlight-python"><pre>pip install geojson</pre></div>
                 <p>Shapely:</p>
                 <div class="highlight-python">
-                  <pre>pip install Shapely==1.2.13</pre>
+                  <pre>pip install Shapely&lt;2</pre>
                 </div>
                 <p>For Mac user: do not forget the following directive:</p>
                 <div class="highlight-python">

--- a/base_geoengine/doc/source/prerequisite.rst
+++ b/base_geoengine/doc/source/prerequisite.rst
@@ -14,7 +14,7 @@ Shapely:
 
 ::
 
- pip install Shapely==1.2.13
+ pip install Shapely<2
 
 For Mac user: do not forget the following directive:
 

--- a/base_geoengine/geo_helper/geo_convertion_helper.py
+++ b/base_geoengine/geo_helper/geo_convertion_helper.py
@@ -5,11 +5,18 @@ import logging
 try:
     import geojson
     from shapely import wkb, wkt
-    from shapely.geometry import asShape
     from shapely.geometry.base import BaseGeometry
 except ImportError:
     logger = logging.getLogger(__name__)
     logger.warning("Shapely or geojson are not available in the sys path")
+
+try:
+    from shapely.geometry import asShape
+except ImportError:
+    logger = logging.getLogger(__name__)
+    logger.warning(
+        "Cannot import asShape. You may be using Shapely v2. Please install v1"
+    )
 
 
 def value_to_shape(value, use_wkb=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # generated from manifests external_dependencies
 geojson
-shapely
+shapely<2
 simplejson


### PR DESCRIPTION
#318 

Module will require refactoring to function with Shapely v2. For now, I've added documentation, instructions and a notice in the try/except around the import.