### PR TITLE
[12.0][FIX] base_geoengine. use shape() instead of asShape()

### DIFF
--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -12,7 +12,7 @@ from .geo_db import create_geo_column
 
 logger = logging.getLogger(__name__)
 try:
-    from shapely.geometry import asShape
+    from shapely.geometry import shape
     from shapely.geometry import Point
     from shapely.geometry.base import BaseGeometry
     from shapely.wkb import loads as wkbloads
@@ -259,7 +259,7 @@ class GeoPoint(GeoField):
         if isinstance(geopoint, BaseGeometry):
             geo_point_instance = geopoint
         else:
-            geo_point_instance = asShape(geojson.loads(geopoint))
+            geo_point_instance = shape(geojson.loads(geopoint))
         params = {
             'coord_x': geo_point_instance.x,
             'coord_y': geo_point_instance.y,

--- a/base_geoengine/geo_helper/geo_convertion_helper.py
+++ b/base_geoengine/geo_helper/geo_convertion_helper.py
@@ -4,7 +4,7 @@ import logging
 
 try:
     from shapely import wkt, wkb
-    from shapely.geometry import asShape
+    from shapely.geometry import shape
     from shapely.geometry.base import BaseGeometry
     import geojson
 except ImportError:
@@ -21,7 +21,7 @@ def value_to_shape(value, use_wkb=False):
         # exception are ressource costly
         if '{' in value:
             geo_dict = geojson.loads(value)
-            return asShape(geo_dict)
+            return shape(geo_dict)
         elif use_wkb:
             return wkb.loads(value, hex=True)
         else:


### PR DESCRIPTION
The method asShape has been removed from shapely.geometry and should be replaced by shape.