### PR TITLE
[14.0][FIX] base_geoengine: restore GeoField attributes

### DIFF
--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -28,6 +28,9 @@ class GeoField(fields.Field):
     """
 
     geo_type = None
+    srid = 3857
+    dim = 2
+    gist_index = True
 
     @property
     def column_format(self):


### PR DESCRIPTION
I do not know exactly what these do, or why they're written twice (it's not very DRY...), but they were in the old history (`14.0-bad-history`) and without them, the module `fieldservice_geoengine` fails to install.

In general, they're used by several other methods of the field itself.