### PR TITLE
[16.0][FIX] base_geoengine: name and order of parameters of the gist index creation function

### DIFF
--- a/base_geoengine/geo_db.py
+++ b/base_geoengine/geo_db.py
@@ -78,7 +78,7 @@ def _postgis_index_name(table, col_name):
     return "{}_{}_gist_index".format(table, col_name)
 
 
-def create_geo_index(cr, columnname, tablename):
+def create_geo_index(cr, tablename, columnname):
     """Create the given index unless it exists."""
     indexname = _postgis_index_name(tablename, columnname)
     if sql.index_exists(cr, indexname):


### PR DESCRIPTION
It's been a while since spatial indexes could not be created on geographic fields. This commit correctly uses the nomenclature of the functions and the parameters to use.
It also correctly creates indexes when the column is newly created and not updated.