### PR TITLE
[16.0][IMP] Allow setup service url on osm type raster layer

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -164,13 +164,21 @@ export class GeoengineRenderer extends Component {
         const source = [];
         source.push(new ol.layer.Tile({source: new ol.source.OSM()}));
         const backgroundLayers = backgrounds.map((background) => {
+            var urls = [];
             switch (background.raster_type) {
                 case "osm":
+                    var osmOptions = {};
+                    if (background.url) {
+                        urls = background.url.split(",");
+                        if (urls.length > 0) {
+                            osmOptions.url = urls[0];
+                        }
+                    }
                     return new ol.layer.Tile({
                         title: background.name,
                         visible: !background.overlay,
                         type: "base",
-                        source: new ol.source.OSM(),
+                        source: new ol.source.OSM(osmOptions),
                     });
                 case "wmts":
                     const {source_opt, tilegrid_opt, layer_opt} =
@@ -217,7 +225,7 @@ export class GeoengineRenderer extends Component {
                         params: JSON.parse(background.params_wms),
                         serverType: background.server_type,
                     };
-                    const urls = background.url.split(",");
+                    urls = background.url.split(",");
                     if (urls.length > 1) {
                         source_opt_wms.urls = urls;
                     } else {


### PR DESCRIPTION
This commit allows you to use other service url than the default one on the OpenStreetMap Raster Layer type

<img width="1119" alt="Screenshot 2024-02-29 at 17 18 12" src="https://github.com/OCA/geospatial/assets/3788941/f419b8d3-6253-4f80-9b4d-1d762f785c10">
