### PR TITLE
[16.0][FIX] base_geoengine: Updated field label

### DIFF
--- a/base_geoengine/models/geo_raster_layer.py
+++ b/base_geoengine/models/geo_raster_layer.py
@@ -48,7 +48,9 @@ class GeoRasterLayer(models.Model):
     params = fields.Char(help="Dictiorary of values for dimensions as JSON")
 
     # wms options
-    params_wms = fields.Char("Params", help="Need to provide at least a LAYERS param")
+    params_wms = fields.Char(
+        "Params WMS", help="Need to provide at least a LAYERS param"
+    )
     server_type = fields.Char(
         help="The type of the remote WMS server: mapserver, geoserver, carmentaserver, or qgis",
     )


### PR DESCRIPTION
   Updated field label from "Params" to "Params WMS" of params_wms in order to avoid below warning during installation:
   
   2024-07-15 12:46:43,553 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (params_wms, params) of geoengine.raster.layer() have the same label: Params. [Modules: base_geoengine and base_geoengine] 