### PR TITLE
[16.0][IMP] base_geoengine: Include edit button in Popup

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
@@ -65,6 +65,26 @@ export class GeoengineController extends Component {
     }
 
     /**
+     * Allow you to edit form view for the filled-in model
+     * from new tab in the browser window.
+     * @param {*} resModel
+     * @param {*} resId
+     */
+    async editRecord(resModel, resId) {
+        const url = window.location.href;
+        const searchParams = new URLSearchParams(url.split("#")[1]);
+        searchParams.set("view_type", "form");
+        searchParams.set("id", resId);
+        searchParams.set("menu_id", searchParams.get("menu_id"));
+        const action_url = url.split("#")[0] + "#" + searchParams.toString();
+        this.actionService.doAction({
+            type: "ir.actions.act_url",
+            target: "_blank",
+            url: action_url,
+        });
+    }
+
+    /**
      * When you finished drawing a new shape, this method is called to open form view and create the record.
      * @param {*} resModel
      * @param {*} field

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.xml
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.xml
@@ -29,6 +29,7 @@
                 data="model.root"
                 editable="editable"
                 openRecord.bind="openRecord"
+                editRecord.bind="editRecord"
                 updateRecord.bind="updateRecord"
                 onClickDiscard.bind="onClickDiscard"
                 createRecord.bind="createRecord"

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -632,6 +632,14 @@ export class GeoengineRenderer extends Component {
     }
 
     /**
+     * When you click on the edit button, it calls the controller's
+     * editRecord method.
+     */
+    onEditButtonClicked() {
+        this.props.editRecord(this.record.resModel, this.record.resId);
+    }
+
+    /**
      * Allows you to change the visibility of layers. This method is called
      * when the user changes raster layers.
      */
@@ -1256,6 +1264,7 @@ GeoengineRenderer.props = {
     archInfo: {type: Object},
     data: {type: Object},
     openRecord: {type: Function},
+    editRecord: {type: Function},
     editable: {type: Boolean, optional: true},
     updateRecord: {type: Function},
     onClickDiscard: {type: Function},

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.scss
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.scss
@@ -65,3 +65,14 @@
 .ol-popup-closer:after {
     content: "✖";
 }
+.ol-popup-editor {
+    text-decoration: none;
+    position: absolute;
+    top: 1px;
+    right: 25px;
+}
+.ol-popup-editor:after {
+    font-family: FontAwesome;
+    content: "\f040";
+    cursor: pointer;
+}

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.xml
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.xml
@@ -14,6 +14,11 @@
             />
         </div>
         <div id="popup" class="ol-popup">
+             <div
+                id="popup-editor"
+                class="ol-popup-editor text-primary"
+                t-on-click="onEditButtonClicked"
+            />
             <div
                 id="popup-closer"
                 class="ol-popup-closer text-primary"

--- a/geoengine_base_geolocalize/tests/test_geoengine_partner.py
+++ b/geoengine_base_geolocalize/tests/test_geoengine_partner.py
@@ -1,5 +1,7 @@
 # Copyright 2015-2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from unittest.mock import MagicMock, patch
+
 from odoo.tests.common import TransactionCase
 
 
@@ -18,7 +20,14 @@ class TestGeoenginePartner(TransactionCase):
         partner_id.partner_longitude = 20
         self.assertTrue(partner_id.geo_point, "Should have geo_point")
 
-    def test_geo_localize(self):
+    @patch("requests.get")
+    def test_geo_localize(self, requests_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json = MagicMock(
+            return_value=[{"lat": "49.9549071", "lon": "5.4085830"}]
+        )
+        requests_get.return_value = mock_response
         vals = {
             "name": "Partner Project",
             "street": "Rue au bois la dame",


### PR DESCRIPTION
   Added edit button in popup of record shown in geoengine view which allows user to edit records by opening new tab in browser window.