### PR TITLE
[16.0][IMP] base_geoengine: Fix Vector Layer related Error

### DIFF
--- a/base_geoengine/i18n/base_geoengine.pot
+++ b/base_geoengine/i18n/base_geoengine.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-29 13:52+0000\n"
+"PO-Revision-Date: 2026-05-29 13:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -105,6 +107,13 @@ msgstr ""
 #. module: base_geoengine
 #: model:ir.model.fields.selection,name:base_geoengine.selection__geoengine_vector_layer__classification__custom
 msgid "Custom"
+msgstr ""
+
+#. module: base_geoengine
+#. odoo-javascript
+#: code:addons/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js:0
+#, python-format
+msgid "Customize view to use Attribute Field: \"%s\""
 msgstr ""
 
 #. module: base_geoengine

--- a/base_geoengine/i18n/it.po
+++ b/base_geoengine/i18n/it.po
@@ -6,15 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2025-09-16 11:42+0000\n"
-"Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
-"Language-Team: none\n"
-"Language: it\n"
+"POT-Creation-Date: 2026-05-29 13:54+0000\n"
+"PO-Revision-Date: 2026-05-29 13:54+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.10.4\n"
+"Plural-Forms: \n"
 
 #. module: base_geoengine
 #. odoo-python
@@ -109,6 +108,13 @@ msgstr "Creato il"
 #: model:ir.model.fields.selection,name:base_geoengine.selection__geoengine_vector_layer__classification__custom
 msgid "Custom"
 msgstr "Personalizzato"
+
+#. module: base_geoengine
+#. odoo-javascript
+#: code:addons/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js:0
+#, python-format
+msgid "Customize view to use Attribute Field: \"%s\""
+msgstr "Personalizza la visualizzazione per utilizzare il campo Attributo: \"%s\""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_ir_ui_view__default_extent

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -24,6 +24,7 @@ import {
     reactive,
     useState,
 } from "@odoo/owl";
+import {sprintf} from "@web/core/utils/strings";
 
 /* CONSTANTS */
 const DEFAULT_BEGIN_COLOR = "#FFFFFF";
@@ -53,6 +54,7 @@ export class GeoengineRenderer extends Component {
         this.orm = useService("orm");
         this.view = useService("view");
         this.user = useService("user");
+        this.notification = useService("notification");
 
         // For related model we need to load all the service needed by RelationalModel
         this.services = {};
@@ -757,8 +759,12 @@ export class GeoengineRenderer extends Component {
         const fields_to_read = this.getFieldsToRead(vector);
         const data = await this.getModelData(vector, fields_to_read);
         this.useRelatedModel(vector, layer, data);
-        const styleInfo = this.styleVectorLayer(vector, data);
-        this.initLegend(styleInfo, vector);
+        if (this.checkAttributeFieldUsage(vector, data)) {
+            const styleInfo = this.styleVectorLayer(vector, data);
+            if (styleInfo) {
+                this.initLegend(styleInfo, vector);
+            }
+        }
     }
 
     async renderVectorLayers() {
@@ -852,9 +858,13 @@ export class GeoengineRenderer extends Component {
     }
 
     styleVectorLayerAndLegend(cfg, data, lv) {
-        const styleInfo = this.styleVectorLayer(cfg, data);
-        this.initLegend(styleInfo, cfg);
-        lv.setStyle(styleInfo.style);
+        if (this.checkAttributeFieldUsage(cfg, data)) {
+            const styleInfo = this.styleVectorLayer(cfg, data);
+            if (styleInfo) {
+                this.initLegend(styleInfo, cfg);
+                lv.setStyle(styleInfo.style);
+            }
+        }
     }
 
     initLegend(styleInfo, cfg) {
@@ -1255,6 +1265,27 @@ export class GeoengineRenderer extends Component {
     extractLayerValues(cfg, data) {
         var indicator = cfg.attribute_field_id[1];
         return data.map((item) => item._values[indicator]);
+    }
+
+    /**
+     * Check vector Layer Attribute Field is defined
+     * by view to display proper legends
+     */
+    checkAttributeFieldUsage(cfg, data) {
+        const indicator_values = this.extractLayerValues(cfg, data);
+        if (indicator_values.some((item) => typeof item === "undefined")) {
+            this.notification.add(
+                sprintf(
+                    this.env._t('Customize view to use Attribute Field: "%s"'),
+                    cfg.attribute_field_id[1]
+                ),
+                {
+                    type: "warning",
+                }
+            );
+            return false;
+        }
+        return true;
     }
 }
 


### PR DESCRIPTION
 Notifying user to define selected attribute_field_id of supported type from vector layer as part of geoengine view xml defintion which avoids below observed JS error.
 
<img width="1429" height="636" alt="image" src="https://github.com/user-attachments/assets/bf225c60-46f2-409e-8e93-e36c4c8caf4a" />
