### PR TITLE
[17.0][IMP][base_geoengine]:  Remove redundant zoom tracking on map move end

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -127,12 +127,6 @@ export class GeoengineRenderer extends Component {
                 ],
                 overlays: [this.overlay],
             });
-            this.map.on("moveend", () => {
-                const newZoom = this.map.getView().getZoom();
-                if (newZoom !== localStorage.getItem("ol-zoom")) {
-                    localStorage.setItem("ol-zoom", newZoom);
-                }
-            });
             this.addMoveEndListenerToMap();
             this.format = new ol.format.GeoJSON({
                 dataProjection: this.map.getView().getProjection(),


### PR DESCRIPTION
It is implemented in the `addMoveEndListenerToMap` 