### PR TITLE
[FIX #412] Load openlayers js separately (because it is not minifieble)

### DIFF
--- a/base_geoengine/__manifest__.py
+++ b/base_geoengine/__manifest__.py
@@ -30,7 +30,6 @@
             ("include", "web._assets_bootstrap"),
         ],
         "base_geoengine.assets_jsLibs_geoengine": [
-            "/base_geoengine/static/lib/ol-10.5.0/ol.js",
             "/base_geoengine/static/lib/chromajs-3.1.2/chroma.js",
             "/base_geoengine/static/lib/geostats-2.1.0/geostats.js",
             "/base_geoengine/static/lib/geostats-2.1.0/geostats.css",

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -30,7 +30,7 @@ import {
     extractFieldsFromArchInfo,
 } from "@web/model/relational_model/utils";
 import {evaluateExpr} from "@web/core/py_js/py";
-import {loadBundle} from "@web/core/assets";
+import {loadBundle, loadJS} from "@web/core/assets";
 import {getTemplate} from "@web/core/templates";
 import {parseXML} from "@web/core/utils/xml";
 import {rasterLayersStore} from "../../../raster_layers_store.esm";
@@ -77,6 +77,7 @@ export class GeoengineRenderer extends Component {
         onWillStart(async () =>
             Promise.all([
                 loadBundle("base_geoengine.assets_jsLibs_geoengine"),
+                loadJS("/base_geoengine/static/lib/ol-10.5.0/ol.js"),
                 this.loadVectorModel(),
                 (this.isGeoengineAdmin = await user.hasGroup(
                     "base_geoengine.group_geoengine_admin"

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
@@ -9,7 +9,7 @@
  */
 
 import {Component, onMounted, onRendered, onWillStart, useEffect} from "@odoo/owl";
-import {loadBundle} from "@web/core/assets";
+import {loadBundle, loadJS} from "@web/core/assets";
 import {registry} from "@web/core/registry";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 import {useService} from "@web/core/utils/hooks";
@@ -20,9 +20,10 @@ export class FieldGeoEngineEditMap extends Component {
         this.id = `map_${this.props.id}`;
         this.orm = useService("orm");
 
-        onWillStart(() =>
-            Promise.all([loadBundle("base_geoengine.assets_jsLibs_geoengine")])
-        );
+        onWillStart(() => Promise.all([
+            loadBundle("base_geoengine.assets_jsLibs_geoengine"),
+            loadJS("/base_geoengine/static/lib/ol-10.5.0/ol.js"),
+        ]));
 
         // Is executed when component is mounted.
         onMounted(async () => {

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
@@ -20,10 +20,12 @@ export class FieldGeoEngineEditMap extends Component {
         this.id = `map_${this.props.id}`;
         this.orm = useService("orm");
 
-        onWillStart(() => Promise.all([
-            loadBundle("base_geoengine.assets_jsLibs_geoengine"),
-            loadJS("/base_geoengine/static/lib/ol-10.5.0/ol.js"),
-        ]));
+        onWillStart(() =>
+            Promise.all([
+                loadBundle("base_geoengine.assets_jsLibs_geoengine"),
+                loadJS("/base_geoengine/static/lib/ol-10.5.0/ol.js"),
+            ])
+        );
 
         // Is executed when component is mounted.
         onMounted(async () => {


### PR DESCRIPTION
openlayers JS library (ol.js) could not be minified by Odoo minifier, because it is already minified. Thus, load it separately without minification (do not include in bundle)