### PR TITLE
[18.0] [FIX] base_geoengine: fix web_icon path to use static/description/icon.png

### DIFF
--- a/base_geoengine/views/base_geoengine_view.xml
+++ b/base_geoengine/views/base_geoengine_view.xml
@@ -3,7 +3,7 @@
     <menuitem
         name="GeoEngine Backend"
         id="geoengine_base_menu"
-        web_icon="base_geoengine,images/map.png"
+        web_icon="base_geoengine,static/description/icon.png"
         groups="group_geoengine_admin"
     />
 </odoo>


### PR DESCRIPTION
The icon is not properly show combination with responsive module.

Before:
<img width="1266" height="310" alt="Screen Shot 2026-03-14 at 7 47 51 AM" src="https://github.com/user-attachments/assets/a3e6097f-7fcd-4e9b-8ed8-889cf61020c6" />

After:

<img width="1273" height="285" alt="Screen Shot 2026-03-14 at 8 13 54 AM" src="https://github.com/user-attachments/assets/f640d5bd-ce01-402e-bc19-a7e59a531f20" />
