### PR TITLE
[16.0][IMP] base_geoengine: Avoid error seen clicking on RecordPanel

### DIFF
--- a/base_geoengine/i18n/base_geoengine.pot
+++ b/base_geoengine/i18n/base_geoengine.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-29 13:34+0000\n"
+"PO-Revision-Date: 2026-05-29 13:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -518,6 +520,13 @@ msgstr ""
 #: code:addons/base_geoengine/models/base.py:0
 #, python-format
 msgid "Please create a view or modify view mode"
+msgstr ""
+
+#. module: base_geoengine
+#. odoo-javascript
+#: code:addons/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js:0
+#, python-format
+msgid "Please update latitude and longitude details for: \"%s\""
 msgstr ""
 
 #. module: base_geoengine

--- a/base_geoengine/i18n/it.po
+++ b/base_geoengine/i18n/it.po
@@ -6,10 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2025-09-16 11:42+0000\n"
-"Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
-"Language-Team: none\n"
-"Language: it\n"
+"POT-Creation-Date: 2026-05-29 13:20+0000\n"
+"PO-Revision-Date: 2026-05-29 13:20+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -539,6 +539,14 @@ msgstr "Parametri WMS"
 #, python-format
 msgid "Please create a view or modify view mode"
 msgstr "Creare una vista o modificare la modalità di visualizzazione"
+
+#. module: base_geoengine
+#. odoo-javascript
+#: code:addons/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js:0
+#, python-format
+msgid "Please update latitude and longitude details for: \"%s\""
+msgstr ""
+"Si prega di aggiornare le coordinate di latitudine e longitudine per: \"%s\""
 
 #. module: base_geoengine
 #: model:ir.model.fields,field_description:base_geoengine.field_ir_model_fields__dim

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -24,6 +24,7 @@ import {
     reactive,
     useState,
 } from "@odoo/owl";
+import {sprintf} from "@web/core/utils/strings";
 
 /* CONSTANTS */
 const DEFAULT_BEGIN_COLOR = "#FFFFFF";
@@ -53,6 +54,7 @@ export class GeoengineRenderer extends Component {
         this.orm = useService("orm");
         this.view = useService("view");
         this.user = useService("user");
+        this.notification = useService("notification");
 
         // For related model we need to load all the service needed by RelationalModel
         this.services = {};
@@ -571,22 +573,35 @@ export class GeoengineRenderer extends Component {
     onDisplayPopupRecord(record) {
         const popup = this.getPopup();
         const feature = this.vectorSource.getFeatureById(record.resId);
-        if (feature !== undefined) {
-            this.mountGeoengineRecord({
-                popup,
-                archInfo: this.props.archInfo,
-                templateDocs: this.props.archInfo.templateDocs,
-                record,
+        if (feature === null) {
+            this.notification.add(
+                sprintf(
+                    this.env._t(
+                        'Please update latitude and longitude details for: "%s"'
+                    ),
+                    record.data.display_name
+                ),
+                {
+                    type: "warning",
+                }
+            );
+            this.clickToHidePopup();
+            return false;
+        }
+        this.mountGeoengineRecord({
+            popup,
+            archInfo: this.props.archInfo,
+            templateDocs: this.props.archInfo.templateDocs,
+            record,
+        });
+        var coord = ol.extent.getCenter(feature.getGeometry().getExtent());
+        this.overlay.setPosition(coord);
+        var map_view = this.map.getView();
+        if (map_view) {
+            map_view.animate({
+                center: feature.getGeometry().getFirstCoordinate(),
+                duration: 500,
             });
-            var coord = ol.extent.getCenter(feature.getGeometry().getExtent());
-            this.overlay.setPosition(coord);
-            var map_view = this.map.getView();
-            if (map_view) {
-                map_view.animate({
-                    center: feature.getGeometry().getFirstCoordinate(),
-                    duration: 500,
-                });
-            }
         }
     }
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 odoo-test-helper
+odoo-addon-base_geoengine @ git+https://github.com/OCA/geospatial.git@refs/pull/417/head#subdirectory=setup/base_geoengine


### PR DESCRIPTION
Depends on #417. When a record in record panel does not contain latitude and
longitude details, it fails with error "feature is null". So, avoiding this error and notifying the user to update required details to view the record.

Below is the error seen without latitude and longitude details:

<img width="1446" height="917" alt="image" src="https://github.com/user-attachments/assets/6e45fa46-eda1-4896-9ad2-61e8da2b49b4" />
