### PR TITLE
[16.0][IMP] geoengine_partner: Updated geoengine view template

### DIFF
--- a/geoengine_partner/views/partner.xml
+++ b/geoengine_partner/views/partner.xml
@@ -20,7 +20,10 @@
     <record id="ir_ui_view_geo_partner" model="ir.ui.view">
         <field name="name">Partner view</field>
         <field name="arch" type="xml">
-            <geoengine editable="1">
+            <geoengine>
+                <!-- display_name field is necessary to display records
+                in the GeoEngine view RecordPanel -->
+                <field name="display_name" />
                 <field name="name" select="1" />
                 <field name="title" />
                 <field name="function" />
@@ -32,15 +35,27 @@
                 <templates>
                   <t t-name="info_box">
                     <b>
-                      Name: <field name="name" />
+                      Name: <field name="name" widget="badge" />
                     </b>
                     <ul>
-                      <li>Title: <field name="title" /> </li>
-                      <li>Function: <field name="function" /> </li>
-                      <li>Website: <field name="website" /> </li>
-                      <li>ZIP: <field name="zip" /> </li>
-                      <li>City: <field name="city" /> </li>
-                      <li>Country: <field name="country_id" /> </li>
+                      <t t-if="record.title.value">
+                         <li>Title: <field name="title" /> </li>
+                      </t>
+                      <t t-if="record.function.value">
+                         <li>Function: <field name="function" /> </li>
+                      </t>
+                      <t t-if="record.website.value">
+                         <li>Website: <field name="website" /> </li>
+                      </t>
+                      <t t-if="record.zip.value">
+                         <li>ZIP: <field name="zip" /> </li>
+                      </t>
+                      <t t-if="record.city.value">
+                         <li>City: <field name="city" /> </li>
+                      </t>
+                      <t t-if="record.country_id.value">
+                         <li>Country: <field name="country_id" /> </li>
+                      </t>
                     </ul>
                   </t>
                 </templates>

--- a/geoengine_partner/views/partner.xml
+++ b/geoengine_partner/views/partner.xml
@@ -32,6 +32,7 @@
                 <field name="city" />
                 <field name="country_id" />
                 <field name="geo_point" />
+                <field name="color" />
                 <templates>
                   <t t-name="info_box">
                     <b>
@@ -75,6 +76,7 @@
         <field name="view_id" ref="ir_ui_view_geo_partner" />
         <field name="geo_repr">basic</field>
         <field name="active_on_startup" eval="True" />
+        <field name="attribute_field_id" ref="base.field_res_partner__color" />
         <field name="layer_opacity">0.8</field>
         <field eval="1" name="nb_class" />
         <field name="begin_color">#FF680A</field>


### PR DESCRIPTION
   Updated geoengine view tempalte which helps to lists all partner related records in geoengine view record panel. Also, updated vector layer "Partner Location" to use default "attribute_field_id" as 'color' field which helps users to locate the location of partners on map when latitude/longitude details available, so that users will be able to view details of partners using popup.
   
   
<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/f449bd42-7b86-4a6c-94c1-2d4e1af23d4e" />
