### PR TITLE
[16.0][IMP] base_geoengine: Display legends for records with coordinates

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -728,7 +728,10 @@ export class GeoengineRenderer extends Component {
             this.styleVectorLayerAndLegend(vector, data, layer);
             this.useRelatedModel(vector, layer, data);
         } else {
-            const data = this.props.data.records;
+            // Filter records with coordinates for styling vector layers & legends
+            const data = this.props.data.records.filter(
+                (record) => record.data[vector.geo_field_id[1]] !== false
+            );
             this.styleVectorLayerAndLegend(vector, data, layer);
             this.addSourceToLayer(data, vector, layer);
         }
@@ -817,7 +820,10 @@ export class GeoengineRenderer extends Component {
             this.styleVectorLayerAndLegend(cfg, data, lv);
             this.useRelatedModel(cfg, lv, data);
         } else {
-            const data = this.props.data.records;
+            const geo_field_id_name = cfg.geo_field_id[1];
+            const data = this.props.data.records.filter(
+                (record) => record.data[geo_field_id_name] !== false
+            );
             if (!data.length) {
                 return new ol.layer.Vector({
                     source: new ol.source.Vector(),
@@ -844,10 +850,13 @@ export class GeoengineRenderer extends Component {
 
     async getModelData(cfg, fields_to_read) {
         const domain = this.evalModelDomain(cfg);
+        const geo_field_id_name = cfg.geo_field_id[1];
         let data = await this.orm.searchRead(cfg.model, [domain][0], fields_to_read);
         const modelsRecords = this.models.find((e) => e.model.resModel === cfg.model)
             .model.records;
-        data = data.map((data) => modelsRecords.find((rec) => rec.resId === data.id));
+        data = data
+            .map((data) => modelsRecords.find((rec) => rec.resId === data.id))
+            .filter((rec) => rec.data[geo_field_id_name] !== false);
         return data;
     }
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 odoo-test-helper
+odoo-addon-base_geoengine @ git+https://github.com/OCA/geospatial.git@refs/pull/454/head#subdirectory=setup/base_geoengine


### PR DESCRIPTION
   While styling legends, using records which has coordinates details in order to display legend information in the geoengine view.

Before this PR fix:
Listing all four locations information in legend
<img width="1918" height="947" alt="image" src="https://github.com/user-attachments/assets/6114e57f-9979-48b4-8714-bfd8e7170284" />

After fix:
Legends display information only for records shown in map(i.e records with coordinates details)

<img width="1918" height="947" alt="image" src="https://github.com/user-attachments/assets/e5b1d2ba-8f71-4447-bc8d-c65290a40a6c" />

