### PR TITLE
[17.0][IMP] base_geoengine: conditional rendering for popup editor based on active edit actions

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.xml
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.xml
@@ -19,6 +19,7 @@
         <div id="popup" class="ol-popup text-start">
             <div
                 id="popup-editor"
+                t-if="props.archInfo.activeActions.edit"
                 class="ol-popup-editor text-primary"
                 t-on-click="onEditButtonClicked"
             />


### PR DESCRIPTION
Hide the pencil icon `popup-editor` in the map popup when `edit="false"` is set on the `<map>` view definition. The button was always visible regardless of the `activeActions.edit` configuration.

Before:
<img width="43" height="35" alt="image" src="https://github.com/user-attachments/assets/653c550e-f74b-4d1e-b299-2d48ee20d443" />

Now:
<img width="46" height="49" alt="image" src="https://github.com/user-attachments/assets/d62bcedb-0d7c-4976-b01d-2e56746c0781" />
