### PR TITLE
[FIX] web_view_leaflet_map: reload markers on search domain change

### DIFF
--- a/web_view_leaflet_map/__manifest__.py
+++ b/web_view_leaflet_map/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Leaflet Map View (OpenStreetMap)",
     "summary": "Add new 'leaflet_map' view, to display markers.",
-    "version": "18.0.1.1.2",
+    "version": "18.0.1.1.3",
     "author": "GRAP, Odoo Community Association (OCA)",
     "maintainers": ["legalsylvain"],
     "website": "https://github.com/OCA/geospatial",

--- a/web_view_leaflet_map/static/src/views/leaflet_map/leaflet_map_renderer.esm.js
+++ b/web_view_leaflet_map/static/src/views/leaflet_map/leaflet_map_renderer.esm.js
@@ -3,7 +3,7 @@ import {useService} from "@web/core/utils/hooks";
 
 /* global L, console, document */
 
-const {Component, onWillStart, onMounted, onPatched, useRef} = owl;
+const {Component, onWillStart, onMounted, onPatched, onWillUpdateProps, useRef} = owl;
 
 export class MapRenderer extends Component {
     static template = "web_view_leaflet_map.MapRenderer";
@@ -58,24 +58,30 @@ export class MapRenderer extends Component {
                 this.renderMarkers();
             }
         });
+
+        // Reload the records when the search domain/context changes (filters,
+        // favorites, ...) so the markers reflect the active search.
+        onWillUpdateProps(async (nextProps) => {
+            await this.loadRecords(nextProps.domain, nextProps.context);
+        });
     }
 
     /**
      * Loads records from the server based on the provided domain and fields.
      * @returns {Promise<void>}
      */
-    async loadRecords() {
+    async loadRecords(domain, context) {
         const fields = this.getFields();
 
         try {
             // Cargar registros usando searchRead
             const records = await this.orm.searchRead(
                 this.resModel,
-                this.props.domain || [],
+                domain === undefined ? this.props.domain || [] : domain,
                 fields,
                 {
                     limit: this.props.limit || 80,
-                    context: this.props.context || {},
+                    context: context === undefined ? this.props.context || {} : context,
                 }
             );
             this.records = records;


### PR DESCRIPTION
## Problem

On the `leaflet_map` view, applying a search **filter** or **favorite** does
not update the markers. The renderer loads its records only in `onWillStart`
and never reacts to later domain changes; `onPatched` re-renders the markers
but from the same, stale `this.records`. As a result the map keeps showing all
records regardless of the active search.

## Fix

Add an `onWillUpdateProps` hook that reloads the records with the new
`domain`/`context` before the component is patched. `loadRecords` now accepts
an optional `domain`/`context` (falling back to `this.props`), so the filtered
result is fetched and `onPatched` then re-renders the up-to-date markers.

No change to the view API; filtering now works on every `leaflet_map` view.

## How to test

1. Open any action using a `leaflet_map` view with a search view that has
   filters (e.g. `web_view_leaflet_map_partner`).
2. Apply a filter or favorite.
3. Before: markers are unchanged. After: markers reflect the filtered records.