### PR TITLE
[18.0][FIX] base_geoengine

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_record/geoengine_record.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_record/geoengine_record.esm.js
@@ -55,7 +55,19 @@ export class GeoengineRecord extends Component {
         return {
             context: this.props.record.context,
             JSON,
-            record: this.props.record,
+            // The info-box template reads fields as `record.<field>.value`.
+            // `this.record` (built by createRecord) exposes every loaded field
+            // as `{value}`. Wrap it in a Proxy so fields referenced in the
+            // template but not loaded in the view resolve to
+            // `{value: undefined}` instead of throwing while rendering.
+            record: new Proxy(this.record, {
+                get(target, prop) {
+                    if (typeof prop === "symbol" || prop in target) {
+                        return target[prop];
+                    }
+                    return {value: undefined};
+                },
+            }),
             read_only_mode: this.props.readonly,
             selection_mode: this.props.forceGlobalClick,
             user_context: user.context,

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.esm.js
@@ -599,6 +599,10 @@ export class GeoengineRenderer extends Component {
 
     zoomOnFeature(record) {
         const feature = this.vectorSource.getFeatureById(record.resId);
+        // Records without geometry have no feature to zoom on.
+        if (!feature) {
+            return;
+        }
         var map_view = this.map.getView();
         if (map_view) {
             map_view.fit(feature.getGeometry(), {maxZoom: 14});
@@ -606,10 +610,14 @@ export class GeoengineRenderer extends Component {
     }
 
     getOriginalZoom() {
-        var extent = this.vectorLayersResult
-            .find((res) => res.values_.visible === true)
-            .getSource()
-            .getExtent();
+        const visibleLayer = this.vectorLayersResult.find(
+            (res) => res.values_.visible === true
+        );
+        // No visible vector layer means there is nothing to fit the view to.
+        if (!visibleLayer) {
+            return;
+        }
+        var extent = visibleLayer.getSource().getExtent();
         var infinite_extent = [Infinity, Infinity, -Infinity, -Infinity];
         if (JSON.stringify(extent) === JSON.stringify(infinite_extent)) {
             extent = [-13360714.671289, 5314503.622, 8284735.328607, 7099727.320865];


### PR DESCRIPTION
@BinhexTeam
T24126

Guard GeoEngine renderer and info-box popup against missing data.

Context:
In the GeoEngine (map) view of base_geoengine, several JavaScript errors occurred when interacting with the map, the records panel, and the infobox popup. These errors were reproduced in Field Service → Orders (map view), but the root cause lies within base_geoengine and affects any model using GeoEngine views.

Bugs fixed:

1. Exception when zooming to a record without geometry.
3. Exception when rendering the infobox popup. The info_box template accesses the fields as record.<field>.value, but renderingContext exposed the relational record (whose fields are in _values/data, not accessible as .value). Furthermore, if the template referenced a field not declared in the view, record.<field> was undefined and .value threw "Cannot read properties of undefined (reading 'value')".