### PR TITLE
[19.0][FIX] web_view_google_map: prompt for API key instead of Google JS error

### DIFF
--- a/web_view_google_map/__manifest__.py
+++ b/web_view_google_map/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Google Map View",
     "summary": "Add a Google Map view type to the Odoo web client",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Open Source Integrators, Gray Matter Logic, "
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/geospatial",

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.esm.js
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.esm.js
@@ -65,6 +65,7 @@ export class GoogleMapRenderer extends Component {
         this.infoWindow = null;
         this.records = [];
         this.theme = "default";
+        this.missingApiKey = false;
 
         const archEl = normalizeArch(this.props.archInfo?.arch || this.props.arch);
         const attrs = archEl.attributes || {};
@@ -80,12 +81,19 @@ export class GoogleMapRenderer extends Component {
         );
 
         onWillStart(async () => {
-            await loadGoogleMaps(this.orm);
+            const maps = await loadGoogleMaps(this.orm);
+            if (!maps) {
+                this.missingApiKey = true;
+                return;
+            }
             await this.loadTheme();
             await this.loadRecords();
         });
 
         onMounted(() => {
+            if (this.missingApiKey) {
+                return;
+            }
             this.initMap();
             this.renderMarkers();
         });
@@ -94,6 +102,16 @@ export class GoogleMapRenderer extends Component {
             if (this.gmap) {
                 this.renderMarkers();
             }
+        });
+    }
+
+    openGoogleMapsSettings() {
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "res.config.settings",
+            views: [[false, "form"]],
+            target: "current",
+            context: {module: "base_google_map"},
         });
     }
 

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.scss
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.scss
@@ -17,3 +17,12 @@
         margin-bottom: 0.25rem;
     }
 }
+
+.o_google_map_missing_key {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 400px;
+    height: 100%;
+    text-align: center;
+}

--- a/web_view_google_map/static/src/views/google_map/google_map_renderer.xml
+++ b/web_view_google_map/static/src/views/google_map/google_map_renderer.xml
@@ -2,7 +2,26 @@
 <templates xml:space="preserve">
     <t t-name="web_view_google_map.GoogleMapRenderer">
         <div class="o_google_map_view h-100" t-ref="root">
-            <div t-ref="mapContainer" class="o_google_map_container h-100" />
+            <div t-if="missingApiKey" class="o_view_nocontent o_google_map_missing_key">
+                <div class="o_nocontent_help">
+                    <p class="o_view_nocontent_smiling_face">
+                        Google Maps API key required
+                    </p>
+                    <p>
+                        Set a valid Google Maps API key to display this map.
+                        Enable the Maps JavaScript API for your key in Google Cloud
+                        Console.
+                    </p>
+                    <button
+                        type="button"
+                        class="btn btn-primary"
+                        t-on-click="openGoogleMapsSettings"
+                    >
+                        Configure API key
+                    </button>
+                </div>
+            </div>
+            <div t-else="" t-ref="mapContainer" class="o_google_map_container h-100" />
         </div>
     </t>
 </templates>

--- a/web_view_google_map/static/src/views/google_map/google_maps_loader.esm.js
+++ b/web_view_google_map/static/src/views/google_map/google_maps_loader.esm.js
@@ -2,11 +2,22 @@ import {loadJS} from "@web/core/assets";
 
 let googleMapsPromise = null;
 
+/** Demo / unset values that must not be sent to Google. */
+const UNUSABLE_API_KEYS = new Set(["", "YOUR_GOOGLE_MAPS_API_KEY"]);
+
+/**
+ * @param {String|false|null|undefined} apiKey
+ * @returns {Boolean}
+ */
+export function isUsableGoogleMapsApiKey(apiKey) {
+    return !UNUSABLE_API_KEYS.has(String(apiKey || "").trim());
+}
+
 /**
  * Load the Google Maps JS API using keys/libraries from ir.config_parameter.
  * Parameters are managed by base_google_map.
  * @param {Object} orm - ORM service (`useService("orm")`)
- * @returns {Promise<typeof google.maps>}
+ * @returns {Promise<typeof google.maps|null>} maps API, or null if no usable key
  */
 export async function loadGoogleMaps(orm) {
     if (window.google?.maps) {
@@ -35,15 +46,17 @@ export async function loadGoogleMaps(orm) {
             ]),
         ]);
 
+        if (!isUsableGoogleMapsApiKey(apiKey)) {
+            return null;
+        }
+
         const url = new URL("https://maps.googleapis.com/maps/api/js");
         url.searchParams.set("v", "quarterly");
         url.searchParams.set(
             "libraries",
             String(libraries || "geometry,places").replace(/^,+|,+$/g, "")
         );
-        if (apiKey) {
-            url.searchParams.set("key", apiKey);
-        }
+        url.searchParams.set("key", String(apiKey).trim());
         // Lang/region may already include "&language=xx" from base_google_map
         const langCode = String(lang || "").includes("=")
             ? String(lang).split("=").pop()


### PR DESCRIPTION
## Summary
- Do not load the Google Maps JS API when the key is missing or the demo placeholder `YOUR_GOOGLE_MAPS_API_KEY`.
- Show an Odoo empty-state with a **Configure API key** button (opens Settings) instead of Google's "Oops! Something went wrong" page.

## Test plan
- [x] Install `web_view_google_map` with empty / placeholder `google.api_key_geocode`
- [x] Open Contacts (or any) Google Map view → see API key prompt, not Google JS error
- [x] Set a valid key in Settings → Google Maps View → map loads


Made with [Cursor](https://cursor.com)